### PR TITLE
feat: Add content page for Snowflake Playbook

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -774,6 +774,39 @@ export default function ExecutiveBrandSite() {
             Download Resume
           </a>
         </div>
+        {/* Portfolio Projects Section */}
+        <div className="mt-4">
+          <p className="font-semibold text-slate-700">Portfolio Projects</p>
+          <div className="space-x-4 mt-2">
+            <a
+              href="/portfolio/edtech-student-success"
+              className="hover:text-slate-700 transition-colors"
+            >
+              EdTech Student Success
+            </a>
+            <span>·</span>
+            <a
+              href="/portfolio/game-theory-policy-impact"
+              className="hover:text-slate-700 transition-colors"
+            >
+              Game Theory Policy Impact
+            </a>
+            <span>·</span>
+            <a
+              href="/portfolio/neuroscience-information-flow"
+              className="hover:text-slate-700 transition-colors"
+            >
+              Neuroscience Information Flow
+            </a>
+            <span>·</span>
+            <a
+              href="/portfolio/snowflake-cost-governance-playbook"
+              className="hover:text-slate-700 transition-colors"
+            >
+              Snowflake Playbook
+            </a>
+          </div>
+        </div>
       </footer>
     </div>
   )

--- a/app/portfolio/snowflake-cost-governance-playbook/page.tsx
+++ b/app/portfolio/snowflake-cost-governance-playbook/page.tsx
@@ -1,0 +1,43 @@
+// app/portfolio/snowflake-cost-governance-playbook/page.tsx
+
+export default function SnowflakePlaybookPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-8 text-center">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2">
+          Snowflake Cost-Governance Framework Playbook
+        </h1>
+        <p className="text-lg text-slate-600">
+          Detailed strategies and insights from the playbook.
+        </p>
+      </header>
+
+      <section className="bg-white shadow-lg rounded-lg p-6 border border-slate-200">
+        <h2 className="text-2xl font-semibold text-slate-800 mb-4">Playbook Overview</h2>
+        <p className="text-slate-700 leading-relaxed mb-4">
+          This page will provide a comprehensive overview of the Snowflake Cost-Governance Framework Playbook.
+          Content is currently under development. Please check back soon for detailed information, case studies,
+          and implementation guides.
+        </p>
+        <div className="bg-slate-50 p-4 rounded-md">
+          <h3 className="text-xl font-medium text-slate-700 mb-2">Key Areas (Coming Soon):</h3>
+          <ul className="list-disc list-inside text-slate-600 space-y-1">
+            <li>Introduction to Snowflake Cost Governance</li>
+            <li>Framework Components and Setup</li>
+            <li>Monitoring and Alerting Strategies</li>
+            <li>Query Optimization Techniques</li>
+            <li>Warehouse Management Best Practices</li>
+            <li>Reporting and Dashboards for Cost Control</li>
+            <li>Case Studies and Real-world Examples</li>
+          </ul>
+        </div>
+      </section>
+
+      <footer className="mt-12 text-center">
+        <a href="/" className="text-blue-600 hover:text-blue-800 transition-colors">
+          &larr; Back to Home
+        </a>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
I've created a new content page for the "Snowflake Cost-Governance Framework Playbook" at `/portfolio/snowflake-cost-governance-playbook/page.tsx`. This page includes placeholder content and a structure for future details.

I also updated the main page's footer (`app/page.tsx`) to include a link to this new playbook page under the "Portfolio Projects" section.