### PR TITLE
Add Trinity proof discipline guardrails

### DIFF
--- a/trinity/brand/proof-discipline.md
+++ b/trinity/brand/proof-discipline.md
@@ -1,0 +1,88 @@
+# Trinity Proof Discipline
+
+## Purpose
+Trinity should feel ambitious, premium, and commercially dangerous without making claims it cannot defend. This document defines how future agents should handle proof, examples, and public-facing claims across Daniel's site and Trinity materials.
+
+## Claim Classes
+
+### Verified Claims
+Use these freely when the underlying evidence exists in the repo, resume, case study notes, analytics, client artifact, or another source Daniel has approved.
+
+Examples:
+- "$4.2M ARR generated"
+- "40% CAC reduction"
+- "150+ business users enabled"
+- "Built an AI-enhanced tutoring platform"
+
+Rule: preserve the exact number, context, and attribution. Do not expand a verified claim into a broader claim.
+
+### Qualified Claims
+Use these when the direction is true but the exact impact is not yet measured.
+
+Examples:
+- "Designed AI workflow concepts for revenue and operations teams"
+- "Building Trinity as an applied AI lab for productized workflows"
+- "Developing reusable AI kits for growth, executive reporting, and diligence workflows"
+
+Rule: write in present-progress or design language. Do not imply customer adoption, revenue, or production deployment unless verified.
+
+### Aspirational Claims
+Use these in vision sections, roadmap sections, and lab narratives, not in proof sections.
+
+Examples:
+- "Trinity is being built to become an applied AI lab for independent wealth creation."
+- "The goal is to turn repeatable AI implementations into sellable products."
+- "Future kits may support PE portfolio intelligence, founder-led growth, and executive decision systems."
+
+Rule: label ambition as ambition. Vision can be bold, but it cannot masquerade as traction.
+
+### Prohibited Claims
+Do not use these unless Daniel provides evidence.
+
+Examples:
+- "Reduced operational overhead by 40% through productized AI workflows"
+- "Deployed proprietary RAG systems for executive decision support"
+- "Used by PE firms"
+- "Portfolio companies increased valuation multiples"
+- "Enterprise-ready security and compliance"
+
+Rule: if a claim would make a buyer think someone already paid for, deployed, or measured Trinity, it must be verified first.
+
+## Public Copy Rules
+
+1. Lead with verified credibility, then introduce Trinity as the next expression of that credibility.
+2. Separate Daniel's past results from Trinity's future roadmap.
+3. Prefer concrete nouns over generic AI language: workflow, kit, audit, implementation, scoring model, research brief, content engine, diligence memo.
+4. Avoid market filler: moat, transformation, unlock, exponential, revolutionary, game-changing, enterprise-grade.
+5. If a phrase sounds like it could belong on any AI agency website, rewrite it around Daniel's actual operating thesis.
+
+## Safer Replacements
+
+Instead of:
+> Reduced operational overhead by 40% through productized AI workflows.
+
+Use:
+> Building productized AI workflows aimed at reducing repetitive revenue and operations work.
+
+Instead of:
+> Deployed proprietary RAG systems for executive decision support.
+
+Use:
+> Designing executive decision workflows that combine business context, retrieval, and structured AI output.
+
+Instead of:
+> Trinity increases portfolio company valuation multiples.
+
+Use:
+> Trinity is being shaped around the kind of operational leverage PE and growth-stage companies care about: better reporting, faster diligence, lower manual work, and clearer revenue signals.
+
+## Agent Checklist
+
+Before editing site copy or product pages, answer:
+- Is this a verified claim, qualified claim, aspiration, or prohibited claim?
+- Would a skeptical buyer ask for evidence?
+- Does this imply Trinity has paying users, production deployments, or measured ROI?
+- Can the sentence be made more specific without inventing traction?
+- Is the claim useful for image and credibility, or is it just hype?
+
+When in doubt, keep the ambition and lower the certainty.


### PR DESCRIPTION
## Summary
- Adds a proof discipline document for Trinity and Daniel brand work
- Defines verified, qualified, aspirational, and prohibited claim classes
- Gives safer replacements for unverified AI/ROI claims so future agents can keep the brand ambitious without inventing traction

Fixes #25

## Verification
- Docs-only change; no build required