### PR TITLE
Add Trinity mission control memo

### DIFF
--- a/trinity/mission-control.md
+++ b/trinity/mission-control.md
@@ -1,0 +1,100 @@
+# Trinity Mission Control
+
+## Mission
+Trinity is being built as an applied AI lab and product engine around Daniel's taste, technical judgment, and commercial instincts.
+
+The point is not to sell another model. The point is to show that Daniel can identify valuable business workflows, package AI capability into usable systems, turn those systems into products, and use the public brand to compound reputation, deal flow, and financial independence.
+
+## Operating Thesis
+Trinity should become three things at once:
+
+1. **Image Layer**: a premium signal that Daniel is an AI application leader, not a generic consultant.
+2. **Product Layer**: sellable AI skills, workflows, kits, and implementation systems.
+3. **Proof Layer**: public lab exhibits, case studies, and demos that show practical AI leverage.
+
+The brand can be ambitious. The claims must stay disciplined.
+
+## Active Lanes
+
+### Jules Lane
+Jules agents produce parallel artifacts: kits, pages, docs, workflows, and scaffolds. Their work should be reviewed for specificity, proof discipline, compliance, and usefulness before merge.
+
+Current emphasis:
+- Growth Kit hardening
+- verified proof inventory
+- `/trinity` storefront v0
+- Executive Kit
+- PE Intelligence Kit
+- lab exhibit template
+
+### Codex Lane
+Codex owns integration and judgment:
+- review Jules PRs
+- merge clean foundation work
+- hold work that overclaims or creates compliance risk
+- keep the mission coherent
+- define launch boundaries
+- prevent the repo from becoming disconnected generated content
+
+## Merge Standards
+
+### Merge Immediately
+Merge when the PR:
+- is documentation-only or narrowly scoped
+- strengthens the Trinity thesis or operating system
+- does not invent traction, customers, revenue, or production deployment
+- has green checks
+- does not conflict with active product-kit branches
+
+### Hold For Hardening
+Hold when the PR:
+- includes unsupported quantified outcomes
+- uses brittle tool or model recommendations as if permanent
+- suggests scraping, outbound, or PII handling without compliance notes
+- reads like generic AI/SaaS copy
+- is useful as a skeleton but not public-ready
+
+### Reject Or Split
+Split when the PR:
+- mixes repo hygiene with product content
+- restructures raw generated scratch while product PRs are active
+- adds heavy dependencies without a concrete app feature
+- makes Trinity look like a prompt dump instead of an applied AI lab
+
+## Current PR Disposition
+
+### Merged Foundation
+- Proof discipline guardrails
+- Trinity brand positioning
+- Trinity site information architecture
+
+### Holding
+- Personal brand bridge: useful direction, but needs proof discipline before site implementation.
+- Growth Kit v1: useful skeleton, but needs claim, compliance, and buyer setup hardening before product use.
+
+## Trinity v0 Boundary
+Trinity v0 should not try to be the whole empire. It should prove the shape.
+
+Minimum v0:
+- `/trinity` page
+- product catalog overview
+- hardened Growth Kit
+- one lab exhibit
+- proof inventory and claim guardrails
+- implementation CTA for custom AI application work
+
+Not v0:
+- payments
+- customer portal
+- full SaaS platform
+- dozens of shallow kits
+- unsupported claims about PE, enterprise, or deployed ROI
+
+## Next Codex Moves
+1. Keep reviewing new Jules PRs as they land.
+2. Merge only clean foundation work or hardened product artifacts.
+3. Convert the best Jules outputs into a coherent Trinity v0 bundle.
+4. Push back on anything that weakens the image, overclaims traction, or creates implementation noise.
+
+## Guiding Standard
+Trinity should feel like a lab with commercial taste: ambitious enough to attract attention, concrete enough to sell, and disciplined enough to be believed.


### PR DESCRIPTION
## Summary
- Adds a Trinity mission-control memo for the Codex integration lane
- Captures the mission, active Jules/Codex lanes, merge standards, held PRs, and Trinity v0 boundary
- Gives future agents a single operating standard for keeping Trinity coherent while parallel work continues

Fixes #34

## Verification
- Docs-only change; no build required