### PR TITLE
Define Trinity v0 launch bundle

### DIFF
--- a/trinity/v0-launch-bundle.md
+++ b/trinity/v0-launch-bundle.md
@@ -1,0 +1,147 @@
+# Trinity v0 Launch Bundle
+
+## Purpose
+Trinity v0 is the smallest public version that can make the brand feel real: an applied AI lab with productized workflows, not a pile of prompts and not a full SaaS platform.
+
+The launch goal is image plus proof of direction. It should make a serious visitor think:
+
+- Daniel has a clear AI application thesis.
+- Trinity has a product catalog shape.
+- There is at least one usable workflow kit.
+- The lab has a public experimentation format.
+- Custom implementation is available for buyers who want the system installed.
+
+## v0 Must Include
+
+### 1. Trinity Public Page
+Route: `/trinity`
+
+Purpose:
+- explain Trinity as an applied AI lab and product catalog
+- present the lab/product/implementation model
+- preview the first kits
+- create a path to book an AI implementation conversation
+
+Minimum sections:
+- hero with Trinity thesis
+- what Trinity is / is not
+- catalog preview
+- lab exhibit preview
+- implementation CTA
+- link back to Daniel credibility
+
+### 2. Proof And Claim Guardrails
+Required files:
+- `trinity/brand/proof-discipline.md`
+- `trinity/brand/proof-inventory.md`
+
+Purpose:
+- keep the brand ambitious without making invented claims
+- separate Daniel's historical credibility from Trinity's roadmap
+- identify what can be used publicly now versus what needs confirmation
+
+### 3. Catalog Overview
+Required file:
+- `trinity/catalog/README.md`
+
+Purpose:
+- explain the product architecture
+- define Skills, Workflows, Kits, and Implementations
+- show the first three kits
+- clarify that buyers are purchasing operational capability, not prompts
+
+### 4. Hardened Growth Kit
+Required folder:
+- `trinity/catalog/growth-kit/`
+
+v0 standard:
+- can be used manually by a real buyer
+- includes setup checklist, implementation guide, compliance notes, QA rubric, skills, workflows, and examples
+- avoids unsupported outcome claims
+- makes clear that human review is part of the system
+
+### 5. One Lab Exhibit
+Required folder:
+- `trinity/lab/`
+
+Required files:
+- `trinity/lab/README.md`
+- `trinity/lab/templates/exhibit-template.md`
+- one credible experiment brief
+
+v0 standard:
+- exhibit is honest about status
+- no fake validation, fake dates, or fake customer traction
+- points toward a productized kit without pretending the kit is already proven by customers
+
+### 6. Implementation CTA
+Purpose:
+- connect product interest to high-ticket AI implementation work
+- position Daniel/Trinity as able to install and customize workflows
+
+v0 CTA language should be direct:
+- "Book an AI Systems Audit"
+- "Request Trinity Implementation"
+- "Discuss a Custom Workflow Build"
+
+Avoid:
+- implying a checkout exists if it does not
+- implying enterprise clients or PE customers exist if they do not
+- sending users to fake domains or placeholder URLs
+
+## v0.5 Candidates
+These can follow immediately after v0 but should not block launch:
+
+- Executive Kit hardened and added to catalog
+- PE Intelligence Kit hardened and added to catalog
+- first case-study style page
+- downloadable PDF or ZIP packaging for Growth Kit
+- Stripe/payment flow
+- email capture for lab updates
+- real OG image and Trinity visual system
+
+## Later
+These are real opportunities, but not v0:
+
+- customer portal
+- SaaS account system
+- live workflow runner
+- hosted agent execution
+- marketplace for many kits
+- community or course layer
+- multi-tenant implementation dashboard
+
+## Do Not Ship In v0
+
+- dozens of placeholder skills
+- generic product specs with no implementation detail
+- fake proof, fake dates, fake customer wins, or fake URLs
+- unsupported quantified claims such as guaranteed 10x output, 75% savings, or valuation multiple expansion
+- scraping-heavy workflows without compliance guidance
+- raw generated files that make Trinity look like a content dump
+
+## Merge Order
+
+Recommended sequence:
+
+1. Proof discipline and proof inventory.
+2. Catalog overview.
+3. Hardened Growth Kit.
+4. Lab exhibit template and one honest exhibit.
+5. `/trinity` page using only merged and hardened content.
+6. Executive/PE kits after their hardening passes.
+
+## Launch Readiness Checklist
+
+- [ ] `/trinity` page builds and has no broken links.
+- [ ] Growth Kit has setup, compliance, QA, workflows, and examples.
+- [ ] Proof inventory exists and is reflected in public copy.
+- [ ] Lab exhibit does not claim validation it cannot prove.
+- [ ] No fake domains, fake CTAs, or invented customer claims.
+- [ ] Current site still builds successfully.
+- [ ] Public copy feels premium, specific, and commercially grounded.
+
+## Strategic Standard
+Trinity v0 should be small enough to ship and serious enough to matter.
+
+It should not pretend the future has already happened. It should make the future look inevitable.


### PR DESCRIPTION
## Summary
- Adds a Trinity v0 launch bundle document
- Defines the minimum public launch scope: /trinity page, proof guardrails, catalog overview, hardened Growth Kit, one lab exhibit, and implementation CTA
- Separates v0, v0.5, later work, and what should not ship
- Captures recommended merge order and launch readiness checklist

Fixes #36

## Verification
- Docs-only change; no build required