### PR TITLE
Create Trinity Catalog README v0

### DIFF
--- a/trinity/catalog/README.md
+++ b/trinity/catalog/README.md
@@ -1,0 +1,33 @@
+# Trinity Product Catalog (The Forge)
+
+This catalog serves as the central index for Trinity's sellable AI assets, ranging from atomic capabilities to comprehensive operational kits.
+
+## Product Hierarchy
+
+Trinity assets are organized into four tiers of increasing complexity and value:
+
+1.  **Skills**: Atomic AI capabilities (e.g., "Extract KPI from PDF", "Classify Lead Sentiment").
+2.  **Workflows**: Automated sequences of skills that solve a specific task (e.g., "Weekly Content Engine").
+3.  **Kits**: Hardened, bundled operational packages that include documentation, compliance guardrails, and implementation guides.
+4.  **Implementations**: Bespoke, high-touch services for custom AI application work.
+
+## The Buyer Promise: Operational Capability
+
+Trinity does not sell "prompts" or "hacks." We deliver **operational capability**.
+
+Every asset in this catalog is designed to be:
+- **Disciplined**: Built on verified claims and realistic outcomes.
+- **Applied**: Focused on practical business leverage, not theoretical R&D.
+- **Hardened**: Includes the necessary "connective tissue" (checklists, QA rubrics, compliance notes) for production use.
+
+## v0 Kit Status
+
+| Kit | Status | Path |
+| :--- | :--- | :--- |
+| **Growth Kit** | v0 Candidate | [`/trinity/catalog/kits/growth-kit/`](./kits/growth-kit/) |
+| **Executive Kit** | v0.5 Candidate | [`/trinity/catalog/kits/executive-kit/`](./kits/executive-kit/) |
+| **PE Intelligence Kit** | v0.5 Candidate | [`/trinity/catalog/kits/pe-intelligence-kit/`](./kits/pe-intelligence-kit/) |
+
+---
+
+*Note: Paths above represent expected locations. Access depends on current merge status of individual kit branches.*


### PR DESCRIPTION
Created a lightweight `trinity/catalog/README.md` to serve as the v0 index for the Trinity Forge. This document defines the catalog hierarchy, the brand promise of delivering operational capability, and lists the status of initial kits (Growth, Executive, PE Intelligence) with merge-safe links.

Fixes #47

---
*PR created automatically by Jules for task [12416796650174167226](https://jules.google.com/task/12416796650174167226) started by @dviveiros3*