### PR TITLE
Harden Trinity Lab Exhibits and proof discipline

### DIFF
--- a/trinity/lab/README.md
+++ b/trinity/lab/README.md
@@ -1,0 +1,26 @@
+# Trinity Lab: Applied AI Exhibits
+
+Trinity Lab is where we pressure-test hypotheses in applied AI. While "The Forge" contains our stable, productized workflows (Kits), the Lab is dedicated to R&D, experimentation, and documenting the build process of emerging AI capabilities.
+
+## The Exhibit Philosophy
+
+We believe that in the AI era, proof is the only valid currency. Trinity Lab Exhibits are public-facing experiment briefs that bridge the gap between "AI hype" and "business leverage."
+
+Each exhibit is designed to show:
+- **The Hypothesis:** What specific business leverage are we trying to create?
+- **The Build:** The technical stack, prompts, and data flow used.
+- **The Proof:** Raw outputs and honest evaluations of performance.
+- **The Lessons:** What failed, what worked, and what's ready for production.
+
+## From Experiment to Catalog
+
+When a Lab Exhibit proves successful and repeatable, it is refined, modularized, and moved into the [Trinity Catalog](../catalog/).
+
+- **Experiments** are raw, technical, and exploratory.
+- **Kits** (in the Catalog) are hardened, implementation-ready workflows designed for immediate deployment.
+
+## Implementation & Custom Builds
+
+If an exhibit addresses a bottleneck in your organization, you don't have to wait for it to become a Kit.
+
+**Contact the Lab** to discuss implementing a custom version of any Lab experiment within your existing data stack.

--- a/trinity/lab/experiments/founder-growth-engine.md
+++ b/trinity/lab/experiments/founder-growth-engine.md
@@ -1,0 +1,54 @@
+# Exhibit 001: Founder Growth Engine
+**Status:** In-Progress / Proposed
+**Date:** [TBD]
+
+## 1. Hypothesis
+A founder's unique perspective can be extracted via high-bandwidth audio and transformed into a multi-channel content engine and outbound prospecting system with < 30 minutes of founder involvement per week.
+
+## 2. Target Buyer & Workflow
+*   **Ideal Persona:** B2B Founders (Series A-C) or Growth-stage CEOs.
+*   **The Bottleneck:** Founders are often the best salespeople but have the least time to write content or research prospects. Outsourcing to generic agencies often results in "low-signal" content that can damage the brand.
+*   **The Proposed Leverage:** Use AI to act as a "synthetic ghostwriter" and "research analyst" that maintains the founder's specific voice and technical depth.
+
+## 3. The Stack
+*   **Ingestion:** Whisper v3 (Transcription)
+*   **Orchestration:** Claude 3.5 Sonnet (for reasoning and voice cloning)
+*   **Intelligence:** GPT-4o (for structured data extraction and research)
+*   **Storage:** Airtable (Workflow state) and Notion (Content Repository)
+
+## 4. Inputs & Context (Proposed)
+*   15-minute weekly voice memo from the founder (answering 3 specific technical/market questions).
+*   Target account list (ideal customer profile).
+*   Founder's previous 10 "high-performing" LinkedIn posts for style training.
+
+## 5. The Build Process (In-Progress)
+1.  **De-noising & Extraction:** Transcribe voice memo and use LLM to extract "Nuggets" (atomic insights).
+2.  **Voice Mapping:** Map these nuggets against the founder's historical writing style using a few-shot prompting strategy.
+3.  **Cross-Channel Generation:**
+    *   Generate 3x LinkedIn posts.
+    *   Generate 1x Technical Deep-dive (Newsletter).
+    *   Extract 5x "Angle Hooks" for outbound prospecting.
+4.  **Signal Matching:** Take the "Angle Hooks" and search target account news to find relevant triggers for personalized outreach.
+
+## 6. Raw Outputs (Simulated)
+*   [Sample LinkedIn Series: "The Death of the Generalist Data Scientist"]
+*   [Sample Outbound Sequence: "Context-Aware Prospecting for CTOs"]
+
+## 7. Evaluation & Proof (Target Metrics)
+*   **Precision:** Aiming for high technical nuance capturing without hallucinating industry jargon.
+*   **Human-in-the-Loop Necessity:** Expected ~10 mins of editing per week to "sharpen" the hooks.
+*   **Commercial Viability:** Designed to provide a high-leverage alternative to traditional content agencies and manual SDR work.
+
+## 8. Lessons & Failures (Anticipated)
+*   **Voice Drift:** Risk of AI adopting a "transcriptionist" tone. Mitigated by "Brand Constraint" prompt blocks.
+*   **Data Freshness:** Reliance on external research tools for signal matching requires robust error handling.
+
+## 9. Next Product Step
+*   [ ] Archive (Failed hypothesis)
+*   [x] **Iteration** (Currently refining the voice-cloning prompts)
+*   [ ] Catalog Candidate (Targeting move to Catalog once initial validation is complete)
+
+---
+
+**Interested in this workflow?**
+This experiment is currently in the Lab. If you want to discuss how this might work for your company, [contact Trinity for an Implementation Audit](../README.md).

--- a/trinity/lab/templates/exhibit-template.md
+++ b/trinity/lab/templates/exhibit-template.md
@@ -1,0 +1,43 @@
+# Exhibit [Number]: [Title]
+**Status:** [Draft / In-Progress / Completed / Productized]
+**Date:** [YYYY-MM-DD]
+
+## 1. Hypothesis
+*What is the core assumption being tested? (e.g., "We can reduce founder-led content creation time by 80% without losing the unique founder voice.")*
+
+## 2. Target Buyer & Workflow
+*   **Ideal Persona:** [e.g., B2B Founder, PE Associate, Head of Revenue]
+*   **The Bottleneck:** [Describe the manual or expensive process this experiment targets]
+*   **The Proposed Leverage:** [How AI changes the unit economics of this workflow]
+
+## 3. The Stack
+*   **Orchestration:** [e.g., LangChain, CrewAI, Manual]
+*   **Models:** [e.g., Claude 3.5 Sonnet, GPT-4o]
+*   **Data/Infrastructure:** [e.g., Pinecone, Postgres, Airtable]
+
+## 4. Inputs & Context
+*Describe the raw data or context required to run the experiment.*
+
+## 5. The Build Process
+*Step-by-step documentation of how the experiment was structured. Include prompt snippets or architecture diagrams where relevant.*
+
+## 6. Raw Outputs
+*Link to or embed examples of what the system produced.*
+
+## 7. Evaluation & Proof
+*   **Precision:** [How accurate was the output?]
+*   **Human-in-the-Loop Necessity:** [How much editing was required?]
+*   **Commercial Viability:** [Is the cost-to-value ratio sustainable?]
+
+## 8. Lessons & Failures
+*What didn't work? What edge cases were discovered? This is the most important section for lab credibility.*
+
+## 9. Next Product Step
+*   [ ] Archive (Failed hypothesis)
+*   [ ] Iteration (New experiment required)
+*   [ ] **Catalog Candidate** (Ready to be turned into a Kit)
+
+---
+
+**Interested in this workflow?**
+This experiment is currently in the Lab. If you want to deploy a version of this in your company today, [contact Trinity for an Implementation Audit](../README.md).


### PR DESCRIPTION
This update hardens the Trinity Lab infrastructure by ensuring experimental exhibits don't overclaim traction or invent validation. It decouples the Lab's R&D narrative from the productized Growth Kit branch by rewriting the Founder Growth Engine exhibit as an in-progress experiment with simulated metrics rather than a finished product. All fake URLs and unsupported economic claims have been removed to maintain brand credibility.

Fixes #43

---
*PR created automatically by Jules for task [3639861027727669185](https://jules.google.com/task/3639861027727669185) started by @dviveiros3*