### PR TITLE
Harden Executive Kit v2: qualify claims and add internal data guidance

### DIFF
--- a/trinity/catalog/executive-kit/README.md
+++ b/trinity/catalog/executive-kit/README.md
@@ -1,0 +1,32 @@
+# Trinity Executive Kit: AI-Powered Reporting & Decision Support
+
+## Product Promise
+High-leverage business intelligence for the founder-operator. The Trinity Executive Kit transforms raw operational data and fragmented updates into board-ready narratives, structured decision memos, and actionable weekly reports. Move from "gut feel" to "data-backed" leadership without the manual reporting overhead.
+
+## Ideal Buyer
+- **Founder-Operators** ($1M–$20M ARR) who are still deeply involved in weekly operations but need to transition to more formal reporting and strategic oversight.
+- **Fractional COOs/CFOs** looking for a standardized, AI-enhanced reporting engine to deploy across multiple clients.
+- **Chiefs of Staff** tasked with synthesizing cross-departmental data into executive summaries and decision frameworks.
+
+## Outcomes
+- **Decision Speed:** Transition from identifying a problem to having a structured decision memo in a fraction of the time usually required for manual synthesis.
+- **Reporting Consistency:** A reliable weekly cadence of business intelligence that identifies anomalies before they become crises.
+- **Stakeholder Confidence:** Board updates and investor narratives that tie operational metrics to long-term value creation.
+- **Clarity of Action:** Meeting briefs that ensure every high-stakes conversation is prepared, focused, and documented.
+
+## What's Included
+1.  **Skills (AI Instructions):** Modular system prompts for:
+    - **Weekly Operator Report:** Synthesizing progress, blockers, and focus areas.
+    - **Decision Memo:** Structured frameworks (e.g., DACI, 1-Way vs 2-Way doors) for critical choices.
+    - **Board Update Narrative:** Translating dry KPIs into a compelling strategic story.
+    - **KPI Anomaly Explanation:** Root-cause analysis and mitigation planning for metric shifts.
+    - **Meeting Brief:** Rapid preparation for high-stakes internal or external meetings.
+2.  **Workflows:** End-to-end specifications for:
+    - **Weekly Executive Reporting Engine:** A process for collecting inputs and generating the weekly intelligence packet.
+    - **Decision Memo Engine:** A workflow for moving from a recognized need to a documented, peer-reviewed decision.
+3.  **Implementation Guide:** Required inputs, suggested cadences, and how to integrate these workflows into your existing stack (Slack, Notion, CRM).
+4.  **Examples:** Realistic sample outputs for weekly reports and decision memos.
+5.  **Sales Page Copy:** Productized claims and positioning for selling these services to your own clients or stakeholders.
+
+## Leverage Through Precision
+This kit is built on the **Trinity Framework**. We don't do "summarization." We do **Synthesis and Strategy**. Every output is designed to facilitate a business decision or provide a high-fidelity signal to leadership.

--- a/trinity/catalog/executive-kit/buyer-setup-checklist.md
+++ b/trinity/catalog/executive-kit/buyer-setup-checklist.md
@@ -1,0 +1,28 @@
+# Buyer Setup Checklist: Trinity Executive Kit
+
+This checklist ensures that the Trinity Executive Kit is implemented with high-fidelity inputs and clear operational accountability.
+
+## 1. Metrics Feeds (The "Truth" Layer)
+- [ ] **Primary Dashboard Access:** Identify the source of truth for North Star KPIs (e.g., Stripe for revenue, HubSpot for pipeline, PostHog for product).
+- [ ] **Snapshot Cadence:** Define who is responsible for providing the raw metric export or screenshot every Friday morning.
+- [ ] **KPI Definitions:** Ensure all team leads agree on the definition of "Active User," "MQL," and "Churn" to avoid AI hallucination based on conflicting data.
+
+## 2. Team-Update Cadence (The "Pulse" Layer)
+- [ ] **Slack/Notion Collection:** Set up a dedicated channel or page for "Friday 5-Minute Updates."
+- [ ] **Lead Accountability:** Assign specific team leads (Product, Sales, Engineering, CS) to provide 3 bullets: Win of the Week, Critical Blocker, Focus for Next Week.
+- [ ] **Deadline Enforcement:** Set an automated reminder for Thursday EOD and Friday 10:00 AM.
+
+## 3. Data Ownership & Access
+- [ ] **LLM Workspace:** Create a dedicated, private workspace (e.g., OpenAI Enterprise, Claude Team, or a secure internal API instance).
+- [ ] **Input Sanitization:** Define what data **cannot** be uploaded (e.g., PII, unhashed customer lists, specific salary data).
+- [ ] **Context Window Management:** Store the "Strategic Context" (Company Mission, Q4 Goals, Org Chart) in the LLM's Project/GPT Knowledge base.
+
+## 4. Reviewers & Approvers
+- [ ] **The "Driver":** Usually the Chief of Staff or a senior operator who runs the reporting engine.
+- [ ] **The "Final Eye":** The CEO or founder who does the 10-minute polish before distribution.
+- [ ] **Sensitive Reviewers:** Identify who must review reports containing HR sentiment or sensitive financial projections.
+
+## 5. Distribution Rules
+- [ ] **Audience Tiers:** Define what goes to the "Leadership Team" vs. "All Hands" vs. "Board of Directors."
+- [ ] **Platform:** Determine where the final report lives (Notion, Slack, Email, or a slide deck).
+- [ ] **Archive:** Ensure all reports and decision memos are saved in a searchable, permanent repository.

--- a/trinity/catalog/executive-kit/examples/sample-decision-memo.md
+++ b/trinity/catalog/executive-kit/examples/sample-decision-memo.md
@@ -1,0 +1,43 @@
+# Example: Decision Memo
+*Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
+
+**Decision:** Should we sunset the "Basic" plan ($49/mo) to focus exclusively on Mid-Market ($299/mo+)?
+
+---
+
+## 1. Context & Problem Statement
+Our "Basic" plan accounts for 60% of our support tickets but only 8% of our revenue. The support overhead is preventing our team from providing the "White Glove" service our Mid-Market and Enterprise clients expect. If we do nothing, our churn in high-value segments will likely increase due to slow support response times.
+
+## 2. Options Considered
+
+### Option A: Complete Sunset
+- **Pros:** Immediate reduction in support load; clear focus on high-value clients.
+- **Cons:** Loss of $12k MRR; potential brand damage in the "startup" community.
+- **Resource Requirements:** Low (1 week of marketing/comm sync).
+- **Reversibility:** 1-Way Door. Once we kick them off, they won't come back easily.
+
+### Option B: "Grandfather" Existing, Close to New
+- **Pros:** Prevents immediate revenue loss; stops the growth of the support burden.
+- **Cons:** Still requires supporting existing legacy users; confusing pricing for a period.
+- **Resource Requirements:** Medium (Engineering needs to handle billing logic).
+- **Reversibility:** 2-Way Door. We can always reopen the plan later.
+
+### Option C: Raise Price of "Basic" to $99/mo
+- **Pros:** Discourages low-intent users while increasing MRR from those who stay.
+- **Cons:** Might not reduce support tickets if the $99 users are just as demanding.
+- **Resource Requirements:** Low (Simple pricing change).
+- **Reversibility:** 2-Way Door.
+
+## 3. Recommendation
+**Option B.** We should grandfather existing users to maintain our current revenue base but immediately stop new sign-ups for the Basic plan. This allows us to focus our sales and support efforts on the segments that drive 90% of our growth.
+
+## 4. DACI Matrix
+- **Driver:** Head of Product
+- **Approver:** CEO
+- **Contributors:** Head of CS, Head of Sales, Lead Dev
+- **Informed:** All Staff
+
+## 5. Success Metrics
+- **3 Months:** Support ticket volume decreases by 30%.
+- **6 Months:** NPS for Mid-Market segments increases from 45 to 60.
+- **12 Months:** Net Revenue Retention (NRR) hits 115%.

--- a/trinity/catalog/executive-kit/examples/sample-weekly-report.md
+++ b/trinity/catalog/executive-kit/examples/sample-weekly-report.md
@@ -1,0 +1,39 @@
+# Example: Weekly Operator Report
+*Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
+
+**Date:** October 27, 2024
+**Company:** Acme SaaS (B2B Fintech)
+
+---
+
+## 1. Executive Summary
+**The Good:** We closed the $50k Enterprise deal with GlobalLogistics, beating our projected sales cycle by 2 weeks.
+**The Bad:** Our churn in the SMB segment spiked this week due to a legacy feature deprecation.
+**The Pivot:** We are pausing the new feature rollout for SMBs to address the "missing" functionality that caused the churn.
+
+## 2. KPI Pulse
+| Metric | Value | WoW Delta | Status |
+| :--- | :--- | :--- | :--- |
+| **Active Subscriptions** | 1,450 | +12 | 🟡 Flat |
+| **Net New ARR** | $62,000 | +$15,000 | 🟢 High |
+| **LTV:CAC** | 3.8x | -0.2x | 🟡 Warning |
+| **Churn Rate (SMB)** | 4.2% | +1.5% | 🔴 Critical |
+
+## 3. High-Level Wins
+- **Sales:** Signed GlobalLogistics ($50k ARR). This validates our move into the Logistics vertical.
+- **Product:** Launched "Smart Invoicing" v2. Initial adoption is at 30% within the first 48 hours.
+- **Marketing:** Content series on "Fintech Compliance" generated 45 high-intent MQLs.
+
+## 4. Critical Blockers & Risks
+- **Engineering:** The API migration is behind schedule by 4 days due to unforeseen edge cases in the legacy database. This *will* delay the Q4 roadmap if not resolved by Wednesday.
+- **Risk:** Competitor "FinanceFlow" just announced a price cut. We need to monitor our win rate in the mid-market segment closely.
+
+## 5. Focus for Next Week
+1.  **Resolve API Migration:** CTO is dedicating 2 senior devs to unblock the migration team.
+2.  **SMB Retention Campaign:** Launching a "feature bridge" webinar to explain the legacy deprecation and offer workarounds.
+3.  **Logistics Vertical Content:** Replicate the "Compliance" content success for the new Logistics target.
+
+## 6. Human Capital Pulse
+- **Sentiment:** Engineering team is slightly stressed due to the migration delay.
+- **Shoutout:** Sarah (Customer Success) handled 15 churn-risk calls this week with a 60% save rate.
+- **Hiring:** Head of Sales candidate in final rounds; expect an offer by Friday.

--- a/trinity/catalog/executive-kit/implementation-guide.md
+++ b/trinity/catalog/executive-kit/implementation-guide.md
@@ -1,0 +1,56 @@
+# Implementation Guide: Trinity Executive Kit
+
+## Overview
+This guide provides the tactical steps to implement the Trinity Executive Kit within your organization. The goal is to move from "manual reporting" to an "AI-enhanced intelligence engine" with minimal friction.
+
+## 1. Required Inputs
+To get the most out of the AI Skills, you need to provide high-fidelity inputs. We recommend setting up the following "Input Channels":
+
+- **The Metrics Feed:** A weekly export or screenshot of your primary dashboard (HubSpot, Stripe, etc.).
+- **The Sentiment Feed:** A 5-minute Friday morning Slack thread where team leads post their "Top 3."
+- **The Strategic Feed:** A "Brain Dump" document (Notion or a simple notes app) where the founder records observations and concerns throughout the week.
+
+## 2. Setting up the Skills
+1.  **Select your LLM:** Choose a model based on the following selection criteria:
+    - **Reasoning Capability:** High-performance models are required for synthesis and strategic inference.
+    - **Context Window:** Sufficient capacity to ingest weekly metrics, team updates, and strategic documents.
+    - **Instruction Following:** Precision in adhering to the structured frameworks provided in this kit.
+    - **Enterprise Privacy:** Ensure the model provider offers data-zero-retention or enterprise-grade privacy for internal business data.
+2.  **Create "Custom Instructions" or "System Prompts":** Copy the content from the `skills/` directory into your LLM's system instructions or save them as "Saved Prompts."
+3.  **Create a Workspace:** If using ChatGPT, create a "GPT" specifically for "Acme Executive Reporting." If using Claude, create a dedicated "Project."
+
+## 3. The Weekly Cadence
+A successful executive reporting engine relies on a consistent rhythm:
+
+- **Thursday EOD:** Remind team leads to submit their weekly bullets.
+- **Friday 10:00 AM:** Collect metrics and team updates.
+- **Friday 1:00 PM:** Run the **Weekly Executive Reporting Engine** workflow.
+- **Friday 4:00 PM:** Executive review and final polish.
+- **Monday 9:00 AM:** Distribute the report to the leadership team.
+
+## 4. Automation (Optional)
+While this kit can be used manually, you can increase leverage through automation:
+
+- **Input Collection:** Use **Make.com** or **Zapier** to automatically pull Friday morning Slack updates into a Notion database.
+- **Reporting:** Use the **OpenAI/Anthropic API** to automatically generate Draft #1 of the report as soon as the final team update is submitted.
+- **Distribution:** Automate the posting of the final report to a specific Slack channel.
+
+## 5. Data Privacy & Internal Handling
+Managing executive-level data requires strict discipline. Follow these guardrails:
+
+- **Internal Metrics:** Round financial figures where possible. Use percentages for growth trends if absolute dollar amounts are restricted by policy.
+- **HR & Team Sentiment:** Never include PII (Personally Identifiable Information) or specific employee names in prompts regarding team sentiment or conflict. Refer to roles or departments (e.g., "Engineering leadership" instead of "John Doe").
+- **Board & Investor Materials:** Use the LLM to draft the *narrative structure*. Manually insert finalized, audited financial figures into the final document after AI generation.
+- **Data Ownership:** Use enterprise accounts where data is not used for model training. Periodically clear prompt history in accordance with your company's data retention policy.
+
+## 6. The Review Process (Human-in-the-Loop)
+**Crucial:** Never ship AI-generated reports without a human review. The review should focus on:
+1.  **Accuracy:** Does the data match the source?
+2.  **Sensitivity:** Are there internal politics or HR issues that the AI missed or mischaracterized?
+3.  **Nuance:** Does the "Focus for Next Week" align with the founder's most recent (unrecorded) strategic shifts?
+
+## 7. Getting Started
+Start small. Don't try to implement all 5 skills and 2 workflows at once.
+1.  **Week 1:** Start with the **Weekly Operator Report** using manual inputs.
+2.  **Week 2:** Introduce the **Decision Memo** framework for at least one critical choice.
+3.  **Month 1:** Refine the inputs and explore basic automation.

--- a/trinity/catalog/executive-kit/sales-page-copy.md
+++ b/trinity/catalog/executive-kit/sales-page-copy.md
@@ -1,0 +1,42 @@
+# Sales Page Copy: Trinity Executive Kit
+
+## Headline
+**Stop "Running" the Business. Start Leading It.**
+
+## Sub-headline
+Standardize your leadership intelligence with the AI-powered Executive Kit. Turn fragmented data into board-ready narratives and high-stakes decision memos in a fraction of the usual time.
+
+---
+
+## The Problem: The "Operator's Trap"
+You're a founder or senior operator. You're deep in the weeds. Every week is a blur of Slack messages, dashboard screenshots, and "gut-feel" decisions. You know you need better reporting, but who has hours to spend on manual reporting?
+- **The Symptom:** You're reactive, not proactive.
+- **The Cost:** Strategic drift, team misalignment, and missed opportunities.
+- **The Result:** You're a bottleneck for your own growth.
+
+## The Solution: The Trinity Executive Kit
+This is not a dashboard. It's a **Reporting & Decision Engine**. Built on the logic of world-class Chiefs of Staff, this kit provides the framework and the AI intelligence to elevate your leadership.
+
+### What You Get:
+- **The Weekly Intelligence Packet:** A synthesized view of your KPIs, wins, and blockers that actually tells you *what to do next*.
+- **The Decision Memo Framework:** Stop making decisions in Slack. Use our AI-enhanced DACI and 1-Way Door frameworks to make choices that stick.
+- **Board-Ready Narratives:** Prepare for your next investor update or board meeting in a fraction of the time, with significantly higher strategic clarity.
+- **Meeting Preparation on Autopilot:** Never walk into a high-stakes meeting unprepared again.
+
+## Why Trinity?
+We don't do "generic AI." We do **Applied Leverage**.
+- **No Fluff:** Every output is designed for a business outcome, not just "summarization."
+- **Practitioner-Led:** Built by operators who have led data teams at Series A-C startups.
+- **System-First:** We give you the skills, the workflows, and the implementation guide to make it permanent.
+
+## Qualified Claims
+- **Efficiency:** Significantly reduce the time spent on weekly reporting while increasing output quality.
+- **Clarity:** Eliminate "I didn't know that was a problem" from your leadership syncs.
+- **Documentation:** Create a permanent, searchable record of every major decision and its rationale.
+
+## Call to Action
+**Upgrade Your Executive OS.**
+[Book a Strategy Audit] | [Download the Kit]
+
+---
+*Note: This kit requires a high-performance LLM (e.g., Claude 3.5 or GPT-4o) and basic internal data hygiene to be effective.*

--- a/trinity/catalog/executive-kit/skills/board-update-narrative.md
+++ b/trinity/catalog/executive-kit/skills/board-update-narrative.md
@@ -1,0 +1,21 @@
+# Skill: Board Update Narrative
+
+## Objective
+To translate technical and operational metrics into a high-level strategic narrative suitable for board members and investors. This skill focuses on the "story" behind the numbers.
+
+## System Instructions
+You are an expert Investor Relations and Strategy Consultant. Your goal is to synthesize the company's performance data into a narrative that builds trust, demonstrates competence, and highlights long-term value creation.
+
+### Output Structure
+1.  **The "Current State" Narrative:** A high-level summary of the company's trajectory since the last update.
+2.  **Strategic Milestone Progress:** How the current performance maps to the long-term vision and annual goals.
+3.  **The "Main Thing":** Identifying the one single theme that defined the period (e.g., "The Quarter of Product-Market Fit Consolidation").
+4.  **Metric Deep Dive (The Context):** Explaining *why* key metrics moved the way they did, focusing on causality rather than just correlation.
+5.  **Forward-Looking Guidance:** What the board should expect in the next period and where their specific advice/input is needed.
+6.  **The "Ask":** A clear request for help or resources from the board.
+
+### Guidelines
+- **Speak in "Business Outcomes":** Instead of "We improved database latency," use "We increased system reliability to support significantly higher customer volume."
+- **Confidence without Arrogance:** Own the failures by showing the learning and the correction.
+- **Investor Mindset:** Focus on things that impact valuation, burn rate, and competitive advantage.
+- **Conciseness is King:** Board members have limited time; maximize "insight per word."

--- a/trinity/catalog/executive-kit/skills/decision-memo.md
+++ b/trinity/catalog/executive-kit/skills/decision-memo.md
@@ -1,0 +1,27 @@
+# Skill: Decision Memo
+
+## Objective
+To provide a structured, objective framework for making and documenting critical business decisions. This skill helps leadership move from intuition-based choices to reasoned, evidence-backed commitments.
+
+## System Instructions
+You are a Strategic Decision Advisor. Your goal is to take a proposed decision or a problem and structure it into a formal Decision Memo. You must apply mental models like "1-Way vs 2-Way Doors" and "DACI" to ensure clarity of ownership and risk.
+
+### Output Structure
+1.  **The Decision:** A clear, 1-sentence statement of what needs to be decided.
+2.  **Context & Problem Statement:** Why is this decision being made now? What happens if we do nothing?
+3.  **Options Considered:** At least 3 distinct paths (including "Do Nothing"). For each:
+    - **Pros/Cons**
+    - **Resource Requirements (Time/Money/People)**
+    - **Reversibility:** Is this a 1-way door (hard to undo) or a 2-way door (easy to pivot)?
+4.  **Recommendation:** Which option is preferred and why?
+5.  **DACI Matrix:**
+    - **Driver:** Who is leading the decision?
+    - **Approver:** Who makes the final call?
+    - **Contributors:** Who provides expertise?
+    - **Informed:** Who needs to know the result?
+6.  **Success Metrics:** How will we know if this was the right decision in 3/6/12 months?
+
+### Guidelines
+- **Be the Devil's Advocate:** Explicitly look for the "hidden risks" in the recommended path.
+- **Enforce constraint:** Don't let the options be variations of the same thing; they should be meaningfully different.
+- **Clarity over length:** A decision memo should be as short as possible while still containing all necessary data for an informed choice.

--- a/trinity/catalog/executive-kit/skills/kpi-anomaly-explanation.md
+++ b/trinity/catalog/executive-kit/skills/kpi-anomaly-explanation.md
@@ -1,0 +1,21 @@
+# Skill: KPI Anomaly Explanation
+
+## Objective
+To provide a rapid, data-driven root cause analysis when a key metric shifts significantly (positively or negatively) outside of expected ranges.
+
+## System Instructions
+You are a Lead Data Analyst and Business Controller. When presented with a metric anomaly, your goal is to hypothesize potential causes, suggest data points to verify those hypotheses, and recommend immediate corrective or amplificatory actions.
+
+### Output Structure
+1.  **Anomaly Description:** A precise definition of what happened (e.g., "CAC increased significantly over the last three days").
+2.  **Primary Hypotheses:** 3-4 potential reasons for the shift, categorized by Internal (e.g., product change, budget shift) and External (e.g., competitor move, seasonality).
+3.  **Validation Steps:** For each hypothesis, what specific data should we pull to confirm or deny it?
+4.  **Immediate Action Plan:**
+    - **Mitigation (if negative):** Stop-gap measures to prevent further bleed.
+    - **Amplification (if positive):** How to double down on what is working.
+5.  **Long-term Prevention/Integration:** How to adjust our monitoring or strategy to account for this in the future.
+
+### Guidelines
+- **Avoid "Maybe":** Be decisive in your hypotheses. It's better to be wrong and corrected by data than to be vague.
+- **Think in Systems:** Consider how a change in one metric (e.g., lower ad spend) might ripple through to another (e.g., higher LTV due to better targeting).
+- **Distinguish Noise from Signal:** If the anomaly is likely a tracking error or a statistical outlier, say so.

--- a/trinity/catalog/executive-kit/skills/meeting-brief.md
+++ b/trinity/catalog/executive-kit/skills/meeting-brief.md
@@ -1,0 +1,24 @@
+# Skill: Meeting Brief
+
+## Objective
+To prepare an executive for a high-stakes meeting by synthesizing participant profiles, historical context, and desired outcomes into a 1-page briefing note.
+
+## System Instructions
+You are a high-level Executive Assistant and Strategic Advisor. Your goal is to ensure the executive walks into their meeting with full situational awareness and a clear plan for success.
+
+### Output Structure
+1.  **Meeting Goal:** What is the single most important outcome for this meeting?
+2.  **Participant Profiles:**
+    - **Name/Title:**
+    - **Likely Perspective/Motivation:** What do they want from this meeting?
+    - **Past Interactions:** (If provided) Summary of previous context.
+3.  **Key Talking Points:** 3-5 critical messages that must be delivered.
+4.  **Anticipated "Hard Questions":** What will they ask that might be difficult to answer? Provide suggested responses.
+5.  **The "Hidden Agenda":** What might be happening below the surface? (e.g., political tensions, budget constraints).
+6.  **Desired Action Items:** What do we want them to commit to before they leave the room?
+
+### Guidelines
+- **Be Brief:** The executive should be able to read this in 2 minutes or less.
+- **Focus on Leverage:** Don't just list facts; list *strategic advantages*.
+- **Use "If/Then" logic:** "If they bring up budget, then pivot to the long-term ROI of X."
+- **Psychological Awareness:** Note the "emotional temperature" of the situation if possible.

--- a/trinity/catalog/executive-kit/skills/weekly-operator-report.md
+++ b/trinity/catalog/executive-kit/skills/weekly-operator-report.md
@@ -1,0 +1,21 @@
+# Skill: Weekly Operator Report
+
+## Objective
+To synthesize raw operational data, project updates, and team feedback into a high-fidelity weekly report that highlights progress, identifies blockers, and aligns the team on the coming week's priorities.
+
+## System Instructions
+You are an expert Chief of Staff and Operations Strategist. Your goal is to transform disparate weekly updates into a cohesive, actionable report for the CEO/Founder. You must filter out noise and amplify "signals" that impact the primary business KPIs.
+
+### Output Structure
+1.  **Executive Summary:** A 3-sentence TL;DR of the week (The Good, The Bad, and The Pivot).
+2.  **KPI Pulse:** A table or list showing the 3-5 "North Star" metrics, their current value, and the delta from last week.
+3.  **High-Level Wins:** 3-5 major accomplishments that moved the needle on strategic goals.
+4.  **Critical Blockers & Risks:** What is currently stuck, and what external risks are emerging?
+5.  **Focus for Next Week:** The top 3 priorities that the leadership team must ensure are unblocked.
+6.  **Human Capital Pulse:** General sentiment, notable individual performances, or team-wide morale issues.
+
+### Guidelines
+- **Avoid passive voice.** Use "We launched X" instead of "X was launched."
+- **Quantify wherever possible.** Instead of "Good growth," use specific, verified metrics (e.g., "15% WoW growth in MQLs").
+- **Focus on the "So What?":** For every update, imply or state the impact on the business.
+- **Maintain a "High-Truth" tone:** Be brutally honest about failures while remaining solution-oriented.

--- a/trinity/catalog/executive-kit/workflows/decision-memo-engine.md
+++ b/trinity/catalog/executive-kit/workflows/decision-memo-engine.md
@@ -1,0 +1,38 @@
+# Workflow: Decision Memo Engine
+
+## Objective
+To standardize how the organization makes high-stakes decisions, ensuring they are documented, peer-reviewed, and based on sound logic.
+
+## The Process
+
+### 1. Recognition (Trigger)
+- A decision is needed when:
+    - A project is stalled due to lack of clarity.
+    - A significant resource allocation (> $10k or > 1 week of team time) is required.
+    - Two department heads disagree on a path forward.
+
+### 2. Information Gathering
+- **The Driver** (from DACI) gathers the core problem, existing data, and at least 2 potential solutions.
+- **The Driver** conducts 15-minute interviews with **Contributors** to understand constraints.
+
+### 3. AI Drafting
+- **Step A:** Use the **Skill: Decision Memo** prompt.
+- **Input:** Provide the gathered problem statement, options, and contributor feedback.
+- **Output:** Draft #1 of the Decision Memo.
+
+### 4. Asynchronous Review
+- The memo is shared with the **Approver** and **Contributors**.
+- They have a defined review period (e.g., 24-48 hours) to leave comments, specifically looking for "Hidden Risks" or "Missing Options."
+
+### 5. Finalization & Sign-off
+- **The Driver** incorporates feedback and presents the final version to the **Approver**.
+- **The Approver** makes the final call (Option A, B, or C).
+- **The Memo** is moved to a "Decisions Made" archive.
+
+### 6. Communication
+- The decision is communicated to the **Informed** group (usually the whole team or relevant department) with a link to the memo for transparency.
+
+## QA Checks
+- **Option Diversity:** Are the options meaningfully different, or just variations of the same theme?
+- **Reversibility:** Is the 1-way/2-way door distinction clearly argued?
+- **Outcome Tracking:** Is there a calendar invite set for 6 months from now to review the success of the decision?

--- a/trinity/catalog/executive-kit/workflows/weekly-executive-reporting-engine.md
+++ b/trinity/catalog/executive-kit/workflows/weekly-executive-reporting-engine.md
@@ -1,0 +1,30 @@
+# Workflow: Weekly Executive Reporting Engine
+
+## Objective
+To create a repeatable, low-friction process for generating a high-fidelity weekly business intelligence packet for the leadership team.
+
+## The Process
+
+### 1. Input Collection (Friday Morning)
+- **Automated Data Pull:** Extract key KPIs from CRM (HubSpot/Salesforce), Analytics (PostHog/Mixpanel), and Finance (Quickbooks/Stripe).
+- **Team Asynchronous Update:** Team leads submit 3 bullets via Slack/Notion: "Biggest Win," "Biggest Blocker," "Focus for Next Week."
+- **Founder Reflection:** 5-minute voice memo or jotting down "What's keeping me up at night?"
+
+### 2. AI Synthesis (Friday Afternoon)
+- **Step A:** Use the **Skill: Weekly Operator Report** prompt.
+- **Input:** Provide the KPI data, team bullets, and founder reflection.
+- **Output:** Draft #1 of the Weekly Report.
+
+### 3. Review & Refine (Friday EOD)
+- **Executive Review:** Founder or Chief of Staff spends 10 minutes reviewing Draft #1.
+- **Fact Check:** Ensure numbers match the dashboards and nuances of team updates are captured.
+- **Tone Polish:** Adjust the narrative to match the specific "voice" of the company.
+
+### 4. Distribution (Monday Morning)
+- **Publish:** Post the finalized report to the #leadership Slack channel or the Notion "Weekly Reports" database.
+- **Link to Decisions:** If a blocker identified in the report requires a major change, trigger the **Decision Memo Engine**.
+
+## QA Checks
+- **Data Integrity:** Do the deltas in the KPI pulse match the raw data?
+- **Actionability:** Does every "Blocker" have an owner or a next step?
+- **Brevity:** Can the report be consumed in under 5 minutes?


### PR DESCRIPTION
Hardened the Trinity Executive Kit v2 by qualifying all quantified outcome claims and adding robust guidance for internal data handling and privacy.

Key changes include:
1. **Claim Hardening:** Removed or qualified claims like "10x strategic clarity" and "up to 75% reporting reduction" in `sales-page-copy.md`, `README.md`, and various skill prompts.
2. **Operational Readiness:** Created `buyer-setup-checklist.md` to guide users through metrics feed setup, team accountability, and data access rules.
3. **Privacy & Security:** Added a dedicated "Data Privacy & Internal Handling" section to `implementation-guide.md`, providing guardrails for handling internal metrics, HR sentiment, and board materials.
4. **Model Agnostic Guidance:** Shifted from specific model recommendations to selection criteria (Reasoning, Context Window, Privacy) to ensure long-term relevance.
5. **Clear Example Labeling:** Added explicit disclaimers to `sample-decision-memo.md` and `sample-weekly-report.md` stating all data and organizations are fictional.

The kit is now credible, safe for founder/operator use, and aligned with Trinity's proof discipline.

Fixes #45

---
*PR created automatically by Jules for task [13770728857227965143](https://jules.google.com/task/13770728857227965143) started by @dviveiros3*