### PR TITLE
Harden PE Intelligence Kit v2: Investor Claims and Confidentiality

### DIFF
--- a/trinity/catalog/pe-intelligence-kit/README.md
+++ b/trinity/catalog/pe-intelligence-kit/README.md
@@ -1,0 +1,45 @@
+# Trinity PE Intelligence Kit: Diligence & Portfolio AI Workflows
+
+## The Promise
+Standardize and accelerate the "intelligence" phase of the investment lifecycle. This kit provides a structured framework for using Large Language Models to screen targets, extract KPIs from unstructured data, and map AI-driven operational leverage across portfolio companies.
+
+## Target Buyer
+- **PE Associates & VPs:** Who need to move from raw data to a draft diligence memo in hours, not days.
+- **VC Platform & Operations Leads:** Who want to provide "AI-readiness" as a value-add service to portfolio companies.
+- **Portfolio Operations Directors:** Tasked with identifying margin expansion opportunities through automation and AI.
+
+## Outcomes & Design Goals
+- **Compressed Diligence Cycles:** Aimed at accelerating the extraction of risks, opportunities, and KPIs from data rooms and public filings.
+- **Standardized Investment Memoranda:** Workflows designed to produce consistent, high-quality analysis following professional investment committee (IC) formats.
+- **Portfolio-Wide AI Mapping:** A repeatable process to screen a portfolio for companies with high potential for AI-driven operational leverage.
+- **Foundational Data Hygiene:** A framework for portfolio companies to transition from manual reporting to AI-ready data infrastructure.
+
+## Simulated Data & Outcomes
+All ROI, time-savings, and financial metrics included in this kit's examples are **simulated for demonstration purposes**. They are intended to illustrate the *type* of intelligence the kit can produce, not to represent verified results from past PE transactions or specific investment outcomes.
+
+## What’s Included
+
+### 1. Skills (Modular AI Prompts)
+- **Company Analysis:** Deep dive into business models, competitive positioning, and market tailwinds.
+- **KPI Extraction:** Automated identification of North Star metrics from messy financial reports and pitch decks.
+- **Diligence Question Generation:** Dynamic generation of probing questions for management based on identified gaps.
+- **Risk/Opportunity Mapping:** Systematic classification of internal and external threats and growth levers.
+- **Portfolio AI Opportunity Scan:** A scoring model to rank companies by "AI leverage potential."
+
+### 2. Workflows (End-to-End Processes)
+- **Target-Company Analysis Workflow:** From raw input to a structured investment memo.
+- **Portfolio AI-Opportunity Workflow:** A roadmap for assessing and prioritizing AI initiatives across multiple assets.
+
+### 3. Artifacts & Guides
+- **Example Diligence Memo:** A business-grade output demonstrating the depth and tone of the kit.
+- **Example AI Opportunity Map:** A visualization of where AI can drive value in a typical B2B SaaS asset.
+- **Implementation Guide:** Step-by-step instructions on data handling, sensitive information protocols, and human-in-the-loop review.
+
+## Privacy & Confidentiality Note (Critical)
+The PE Intelligence Kit is designed for professional use within secure, enterprise-grade AI environments.
+
+**Strict Guardrails:**
+- **No Public LLMs:** Users are strictly cautioned against uploading non-anonymized, sensitive, or proprietary company data (MNPI) to public AI models.
+- **Enterprise Environments Only:** Only deploy these workflows in privacy-compliant environments (e.g., Azure OpenAI, Private Claude Instances, or AWS Bedrock) where data is not used for model training.
+- **Anonymization First:** All inputs should be sanitized, removing PII and rounding sensitive financial figures, even when using enterprise AI.
+- **Human Oversight:** All AI-generated outputs must undergo rigorous human review and verification before being used for investment decisions.

--- a/trinity/catalog/pe-intelligence-kit/buyer-setup-checklist.md
+++ b/trinity/catalog/pe-intelligence-kit/buyer-setup-checklist.md
@@ -1,0 +1,27 @@
+# PE Intelligence Kit: Buyer Setup Checklist
+
+This checklist ensures your environment and data are properly prepared before deploying the PE Intelligence Kit workflows. Follow these steps to maintain confidentiality and maximize the quality of AI-generated insights.
+
+## 1. Environment Verification
+- [ ] **Enterprise-Grade AI Access:** Ensure you are using an enterprise instance (e.g., ChatGPT Enterprise, Claude for Business, Azure OpenAI) where data is not used for training.
+- [ ] **Compliance Approval:** Verify with your firm's IT or Compliance officer that the selected AI environment is approved for handling proprietary deal data.
+- [ ] **Secure Storage:** Confirm that raw, un-sanitized documents are stored only in firm-approved secure locations (e.g., encrypted cloud storage, approved VDRs).
+
+## 2. Data Sanitization (Input Preparation)
+- [ ] **PII Scrubbing:** Remove names, personal emails, and phone numbers from all CIMs, management presentations, and data room exports.
+- [ ] **Financial Rounding:** Round specific financial figures to the nearest significant unit (e.g., millions or hundred-thousands) to prevent reconstruction of exact tables.
+- [ ] **Counterparty Anonymization:** Replace specific customer, supplier, or partner names with generic identifiers (e.g., 'Key Customer A', 'Logistics Partner B').
+- [ ] **Trade Secret Redaction:** Replace highly specific technical descriptions or proprietary processes with high-level functional descriptions.
+
+## 3. Workflow Configuration
+- [ ] **Model Selection:** Configure workflows to use high-reasoning models (e.g., Claude 3.5 Sonnet, GPT-4o) for complex diligence tasks.
+- [ ] **Context Window Check:** Ensure the chosen tool can handle the token volume of your combined input documents (aim for 100k+ token support).
+- [ ] **Human-in-the-Loop (HITL) Points:** Identify where in the process an analyst will review intermediate outputs before proceeding to the next step.
+
+## 4. Quality Control & Review
+- [ ] **Primary Source Verification:** Assign an analyst to verify all AI-extracted KPIs against the original source documents.
+- [ ] **Tone & Judgment Review:** Review all generated memos for professional tone and ensure AI 'hypotheses' are clearly labeled and scrutinized.
+- [ ] **Final Compliance Pass:** Ensure all final artifacts adhere to internal guidelines for investment committee materials.
+
+---
+**Disclaimer:** This checklist is a framework for operational readiness and does not constitute legal or compliance advice.

--- a/trinity/catalog/pe-intelligence-kit/examples/ai-opportunity-map.md
+++ b/trinity/catalog/pe-intelligence-kit/examples/ai-opportunity-map.md
@@ -1,0 +1,30 @@
+# Example: AI Opportunity Map (Simulated Data)
+**Note: All company names, financial metrics, and ROI figures in this example are simulated for demonstration purposes.**
+
+**Portfolio:** Trinity Growth Fund I
+**Focus:** Margin Expansion via Operational AI
+
+---
+
+### Portfolio Scan Results (Top 3 Targets)
+
+| Company | Sector | AI Leverage Score | Primary Use Case | Impact Goal |
+| :--- | :--- | :---: | :--- | :--- |
+| **LogiStream** | Logistics Tech | 9/10 | Automated BOL processing | 40% reduction in back-office OpEx |
+| **CarePath** | Health Services | 8/10 | AI-assisted medical coding | 15% increase in billing accuracy |
+| **FinGuard** | Fintech / Compliance| 7/10 | Automated AML/KYC review | 2x throughput on new account opening |
+
+---
+
+### Deep Dive: LogiStream Opportunity
+**The Problem:** LogiStream employs 45 FTEs just to manually transcribe data from Bill of Lading (BOL) PDFs into their core ERP. This process is slow, error-prone, and scales linearly with volume.
+
+**The AI Solution:** Implement a vision-LLM pipeline to automatically extract BOL data with a 'Human-in-the-loop' (HITL) for low-confidence scores.
+
+**Estimated ROI:**
+- **Annual Savings:** ~$1.2M in labor costs.
+- **Speed:** Processing time per document from 6 mins to < 30 seconds.
+- **Enterprise Value:** At a 12x EBITDA multiple, this operational improvement creates **$14.4M in incremental EV**.
+
+---
+**Disclaimer:** This is a sample output generated using Trinity PE Kit 'Skills'. It is intended for illustrative purposes and contains simulated data.

--- a/trinity/catalog/pe-intelligence-kit/examples/diligence-memo.md
+++ b/trinity/catalog/pe-intelligence-kit/examples/diligence-memo.md
@@ -1,0 +1,38 @@
+# Example: Preliminary Diligence Memo (Simulated Data)
+**Note: All company names, project code names, and financial data in this example are simulated for demonstration purposes.**
+
+**Company:** Project 'Azure' (Anonymized B2B SaaS)
+**Date:** October 2024
+**Stage:** Preliminary Review
+
+---
+
+### 1. Executive Summary
+Project Azure is a mid-market ERP solution for specialized manufacturing firms. They provide an end-to-end OS for production scheduling, inventory management, and financial reporting.
+
+### 2. Business Model Analysis
+- **Revenue:** 85% SaaS subscription; 15% implementation services.
+- **Moat:** Deep integration into the customer's physical shop floor. High switching costs due to the complexity of production re-scheduling.
+- **Scalability:** High gross margins (82%) indicate strong unit economics, though implementation remains a slight bottleneck for growth.
+
+### 3. KPI Extraction Summary
+| Metric | FY2022 | FY2023 | LTM (Aug 2024) |
+| :--- | :--- | :--- | :--- |
+| **ARR** | $12.4M | $18.2M | $22.1M |
+| **YoY Growth** | 42% | 47% | 38% |
+| **Net Dollar Retention** | 104% | 106% | 102% |
+| **CAC Payback** | 14 Mo | 16 Mo | 19 Mo |
+| **EBITDA Margin** | (12%) | (4%) | 2% |
+
+### 4. Key Risks & Opportunities
+- **Risk (Internal):** High Technical Debt. The core database architecture is legacy, potentially limiting future API integrations.
+- **Risk (External):** Competitor 'Project Cobalt' recently raised $50M to target the same niche with a cloud-native product.
+- **Opportunity:** AI-driven production scheduling. Replacing manual 'Excel-based' scheduling with an optimization engine could reduce customer waste by 15-20%, a major selling point.
+
+### 5. Recommended Management Questions
+1. "The CAC payback period has trended from 14 to 19 months. Is this driven by increased competition or a shift in sales channel mix?"
+2. "Explain the recent slight dip in NDR (106% to 102%). Was this driven by specific logo churn or contraction within the existing base?"
+3. "What is the timeline for the 'V3' cloud-native rollout mentioned in the board deck, and what are the key migration risks for current legacy users?"
+
+---
+**Disclaimer:** This is a sample output generated using Trinity PE Kit 'Skills'. It is intended for illustrative purposes and contains simulated data.

--- a/trinity/catalog/pe-intelligence-kit/implementation-guide.md
+++ b/trinity/catalog/pe-intelligence-kit/implementation-guide.md
@@ -1,0 +1,30 @@
+# PE Intelligence Kit: Implementation Guide
+
+## Required Inputs
+To get the most out of this kit, you should have the following materials (redacted as per privacy guidelines):
+1. **CIM (Confidential Information Memorandum):** For the 'Company Analysis' and 'Risk Mapping' skills.
+2. **Financial Summaries (Excel or PDF):** For 'KPI Extraction'.
+3. **Management Presentations:** To identify the 'Narrative vs. Data' gaps for 'Question Generation'.
+4. **Portfolio Survey Data:** For the 'Portfolio AI Opportunity Scan'.
+
+## Redaction & Confidentiality Protocol
+**Crucial:** Investment data often contains Material Non-Public Information (MNPI). Do not upload sensitive data to public AI interfaces.
+
+1. **PII Removal:** Manually or programmatically remove names, addresses, and phone numbers of employees or customers.
+2. **Precision Reduction (Financials):** Round exact dollar amounts (e.g., $12,456,782 → $12.5M) to prevent the reconstruction of sensitive tables or the identification of specific transactions.
+3. **Proprietary Technology:** Describe sensitive trade secrets or "secret sauce" in generic terms (e.g., 'A proprietary optimization algorithm' vs. 'The exact logic for X').
+4. **Counterparty Anonymization:** Use placeholders for specific customers, suppliers, or partners (e.g., 'Customer A', 'Major Cloud Provider') unless using a fully private enterprise environment.
+5. **Data Room Integrity:** When working with Virtual Data Rooms (VDRs), ensure your AI environment is approved by the firm's compliance officer for handling proprietary diligence materials.
+
+## Recommended Technology Stack (Enterprise Only)
+- **AI Model:** Claude 3.5 Sonnet (for reasoning) or GPT-4o (for data extraction).
+- **Environment:** Use Enterprise versions with data privacy guarantees (e.g., ChatGPT Enterprise, Poe for Business, or AWS Bedrock).
+- **Document Processing:** Use a tool that supports large context windows (100k+ tokens) to process entire data rooms at once.
+
+## The Review Process (Human-in-the-Loop)
+AI-generated diligence materials should **never** be sent to an Investment Committee or external clients without rigorous human review.
+
+1. **Verification (Primary Source):** Cross-check all extracted KPIs and financial figures against the original source documents (audited financials, tax returns).
+2. **Contextualization:** AI cannot 'know' the reputation of a management team, the nuances of a specific regional market, or the political landscape of a deal. These must be added by the analyst.
+3. **Tone Check:** Ensure the AI hasn't been overly optimistic or pessimistic. Maintain a neutral, professional 'Diligence Tone' as defined by your firm’s standards.
+4. **Compliance Approval:** Ensure final outputs adhere to internal compliance and legal guidelines regarding investment recommendations.

--- a/trinity/catalog/pe-intelligence-kit/sales-page-copy.md
+++ b/trinity/catalog/pe-intelligence-kit/sales-page-copy.md
@@ -1,0 +1,26 @@
+# Trinity Kit: PE/VC Intelligence
+
+## The Strategic Edge for Modern Investors
+In a market where deal speed and operational leverage are the primary drivers of alpha, the ability to rapidly process intelligence is no longer optional.
+
+The Trinity PE Intelligence Kit is not a collection of generic prompts. It is a structured framework designed to move investment professionals from "raw data room" to "strategic conviction" in a fraction of the usual time.
+
+## What it Solves
+- **The "Data Room Fog":** Stop drowning in hundreds of PDFs. Use the kit to extract the narrative, the numbers, and the "unknown unknowns" in minutes.
+- **The "Generic Diligence" Trap:** Move beyond surface-level observations. Our skills are tuned to probe for the structural risks and AI-driven growth levers that matter to an exit.
+- **Portfolio Stagnation:** Systematically identify which companies in your portfolio are primed for margin expansion through AI, and which ones are at risk of disruption.
+
+## Premium Workflows
+### 1. The Diligence Engine
+A multi-stage workflow that ingests company data and produces high-grade investment committee drafts, risk maps, and management questions.
+
+### 2. The Portfolio Alpha Scanner
+A scoring and prioritization framework for Platform teams to deploy AI resources where they will have the highest impact on Enterprise Value.
+
+## Built for Precision and Restraint
+Aligned with the **Trinity Proof Discipline**, this kit is designed for practitioners. We don't promise "fully automated diligence"—we provide the framework that allows investment professionals to focus on high-leverage judgment rather than manual data synthesis.
+
+## Accessing the Kit
+The PE Intelligence Kit is available as a productized workflow module. It includes all prompts, workflow specifications, implementation guides, and example artifacts.
+
+[Book a Strategic Review to Discuss Deployment]

--- a/trinity/catalog/pe-intelligence-kit/skills/company-analysis.md
+++ b/trinity/catalog/pe-intelligence-kit/skills/company-analysis.md
@@ -1,0 +1,29 @@
+# Skill: Company Analysis
+
+## Objective
+Generate a high-level strategic overview of a target company's business model, value proposition, and competitive position based on provided documents (e.g., pitch decks, website copy, industry reports).
+
+## Prompt Specification
+"Analyze the provided data for [Company Name]. Structure your response for a Private Equity investment committee.
+
+### 1. Executive Summary
+- Provide a 2-sentence description of what the company does and its primary value proposition.
+- Identify the core customer segment.
+
+### 2. Business Model Analysis
+- Revenue Streams: How does the company make money? (SaaS, transactional, etc.)
+- Scalability: How capital-intensive is the growth?
+- Moat/Defensibility: What prevents competitors from displacing them?
+
+### 3. Market Positioning
+- Relative to [Key Competitors], where does this company sit? (Price leader, feature leader, niche specialist?)
+- What macro trends are favoring or hindering this business?
+
+### 4. Preliminary Thesis
+- Why would a PE firm want to own this asset? (e.g., consolidation play, margin expansion, product expansion).
+
+### 5. Critical Gaps
+- What information is missing from the provided data that is essential for a 'Go/No-Go' decision?"
+
+## Usage Note
+Best used in the 'Screening' phase of diligence. Avoid using highly sensitive financial data in public LLM instances.

--- a/trinity/catalog/pe-intelligence-kit/skills/diligence-questions.md
+++ b/trinity/catalog/pe-intelligence-kit/skills/diligence-questions.md
@@ -1,0 +1,20 @@
+# Skill: Diligence Question Generation
+
+## Objective
+Generate a list of high-impact questions for management based on an initial review of the company's materials and identified risks/gaps.
+
+## Prompt Specification
+"Based on the analysis of [Company Name] provided in [Context/Analysis Doc], generate a list of 10-15 strategic questions for the management team.
+
+### Focus Areas:
+1. **The 'Why Now':** Why is the company seeking investment/sale at this specific time?
+2. **Growth Sustainability:** How dependent is growth on a single channel or customer?
+3. **Product Roadmap:** How much R&D is 'maintenance' vs. 'innovation'?
+4. **Churn Drivers:** For any churn spikes, what were the root causes and how were they addressed?
+5. **Team Dynamics:** What are the critical hiring needs in the next 12 months?
+
+### Tone:
+Professional, probing, and direct. The goal is to uncover 'unknown unknowns'.
+
+### Output Format:
+Group questions by category (e.g., Sales & Marketing, Product & Tech, Finance & Ops)."

--- a/trinity/catalog/pe-intelligence-kit/skills/kpi-extraction.md
+++ b/trinity/catalog/pe-intelligence-kit/skills/kpi-extraction.md
@@ -1,0 +1,25 @@
+# Skill: KPI Extraction
+
+## Objective
+Identify and extract key performance indicators (KPIs) from unstructured or semi-structured data sources like management presentations, board decks, or financial summaries.
+
+## Prompt Specification
+"You are a financial analyst specializing in [Industry, e.g., B2B SaaS]. Review the following document and extract the following KPIs for the last 3 fiscal periods.
+
+### Required Metrics:
+1. **Revenue Metrics:** ARR, GAAP Revenue, Growth Rate (YoY/QoQ).
+2. **Efficiency Metrics:** Magic Number, Rule of 40, Burn Multiple.
+3. **Customer Metrics:** CAC, LTV, Churn (Logo & Net Revenue), NDR/GRR.
+4. **Profitability:** Gross Margin, EBITDA Margin.
+
+### Formatting:
+- Present the data in a markdown table.
+- If a metric is not explicitly stated, attempt to calculate it from available data or mark as 'Not Found'.
+- Cite the page number or section where the data was found.
+
+### Quality Check:
+- Flag any inconsistencies (e.g., ARR that doesn't align with stated growth rates).
+- Highlight metrics that are significantly above or below industry benchmarks for a [Stage, e.g., Series B] company."
+
+## Usage Note
+Ensure all PII (Personally Identifiable Information) is redacted from the input documents before processing.

--- a/trinity/catalog/pe-intelligence-kit/skills/portfolio-scan.md
+++ b/trinity/catalog/pe-intelligence-kit/skills/portfolio-scan.md
@@ -1,0 +1,25 @@
+# Skill: Portfolio AI Opportunity Scan
+
+## Objective
+Rank a list of portfolio companies by their potential for AI-driven operational leverage and margin expansion.
+
+## Prompt Specification
+"Analyze the following portfolio of [Number] companies. For each company, provide an 'AI Leverage Score' (1-10) and a brief justification.
+
+### Scoring Criteria:
+1. **Data Richness:** Does the company own proprietary, structured data?
+2. **Process Repetitivity:** How much of the core service is manual/rule-based?
+3. **Customer Interaction:** Is there a high volume of text/voice interaction with customers?
+4. **Content Generation:** Does the business require high volumes of marketing or technical content?
+5. **Technical Readiness:** What is the state of their current data stack (if known)?
+
+### Output Format:
+A ranked table with the following columns:
+- Company Name
+- Sector
+- AI Leverage Score
+- Top 2 AI Use Cases (e.g., 'Automated Support', 'Predictive Maintenance')
+- Expected Impact (e.g., 'EBITDA expansion', 'Churn reduction')"
+
+## Usage Note
+This is a high-level scan intended for 'Platform' teams to prioritize where to deploy AI consulting resources.

--- a/trinity/catalog/pe-intelligence-kit/skills/risk-mapping.md
+++ b/trinity/catalog/pe-intelligence-kit/skills/risk-mapping.md
@@ -1,0 +1,26 @@
+# Skill: Risk/Opportunity Mapping
+
+## Objective
+Systematically identify and categorize risks and opportunities associated with a target investment.
+
+## Prompt Specification
+"Construct a Risk/Opportunity matrix for [Company Name]. Use the following framework:
+
+### 1. External Risks (Market, Regulatory, Macro)
+- What could go wrong outside the company's control? (e.g., interest rates, new competitors, GDPR changes).
+
+### 2. Internal Risks (Execution, Tech Debt, Key Man Risk)
+- What are the structural weaknesses within the organization?
+
+### 3. Immediate Opportunities (Quick Wins)
+- Where can the new owner add value in the first 100 days? (e.g., pricing optimization, vendor consolidation).
+
+### 4. Strategic Opportunities (Long-term Upside)
+- Where is the potential for 2x-5x growth? (e.g., geographic expansion, M&A roll-up).
+
+### Output format:
+For each item, provide:
+- **Title:** Brief description.
+- **Impact:** High/Medium/Low.
+- **Likelihood:** High/Medium/Low.
+- **Mitigation/Capture Strategy:** One-sentence recommendation for the buyer."

--- a/trinity/catalog/pe-intelligence-kit/workflows/portfolio-opportunity.md
+++ b/trinity/catalog/pe-intelligence-kit/workflows/portfolio-opportunity.md
@@ -1,0 +1,28 @@
+# Workflow: Portfolio AI-Opportunity Workflow
+
+## Overview
+A framework for PE/VC firms to systematically assess and activate AI-driven value creation across their entire portfolio.
+
+## The Process
+
+### Step 1: Data Gathering
+- **Request:** Send a standardized 'Tech & Data Survey' to all portfolio company CTOs/Heads of Product.
+- **Goal:** Understand current stack, data availability, and existing AI experiments.
+
+### Step 2: Portfolio-Wide Scanning
+- **Action:** Run `Skill: Portfolio AI Opportunity Scan` on the survey results.
+- **Output:** A prioritized ranking of companies with the highest 'AI Leverage Potential'.
+
+### Step 3: Deep-Dive Workshops
+- **Action:** For the highest-scoring companies, conduct a 1-day 'AI Opportunity Mapping' workshop.
+- **Focus:** Identify specific ROI-positive use cases (e.g., 'If we automate a portion of high-volume customer support tasks at Company X, how does that impact EBITDA?').
+
+### Step 4: Pilot Design & Execution
+- **Action:** Select 1-2 'Proof of Concept' (PoC) projects per target company.
+- **Constraint:** Use a 'Build vs. Buy' framework. Favor existing tool integrations over custom RAG builds where possible.
+
+### Step 5: Knowledge Sharing
+- **Action:** Create a portfolio-wide 'AI Playbook' to share learnings and vetted vendors across all companies.
+
+## Design Goal
+To provide a structured path toward increasing portfolio-wide operational efficiency and building a stronger 'AI-Enabled' narrative for future exits.

--- a/trinity/catalog/pe-intelligence-kit/workflows/target-analysis.md
+++ b/trinity/catalog/pe-intelligence-kit/workflows/target-analysis.md
@@ -1,0 +1,32 @@
+# Workflow: Target-Company Analysis
+
+## Overview
+A structured, multi-step process to move from raw data room access to a finalized draft of an Investment Committee (IC) memo.
+
+## The Process
+
+### Phase 1: Ingestion & Redaction
+- **Input:** Raw documents (CIM, Management Presentation, Board Decks).
+- **Action:** Use a script or manual process to redact PII (Personally Identifiable Information) and highly sensitive trade secrets.
+- **Output:** 'Clean' text files for LLM processing.
+
+### Phase 2: Structural Extraction (Parallel Processing)
+- **Step A:** Run `Skill: Company Analysis` to build the narrative foundation.
+- **Step B:** Run `Skill: KPI Extraction` to build the financial data table.
+- **Output:** Two draft sections of the memo.
+
+### Phase 3: Risk & Question Synthesis
+- **Step C:** Feed Phase 2 outputs into `Skill: Risk/Opportunity Mapping`.
+- **Step D:** Run `Skill: Diligence Question Generation` based on identified risks.
+- **Output:** A prioritized list of diligence workstreams and management questions.
+
+### Phase 4: Human-in-the-Loop Review
+- **Action:** An Associate/VP reviews the AI-generated outputs for hallucinations or missing context.
+- **Action:** Manual layer of industry-specific 'tribal knowledge' added.
+
+### Phase 5: Final IC Memo Assembly
+- **Action:** Combine sections into a standardized firm template.
+- **Output:** Final draft memo for internal review.
+
+## Efficiency Gain
+Hypothesis: **60-70% time reduction** for the initial 'Drafting' and 'Synthesis' phases of diligence, to be verified through user testing.


### PR DESCRIPTION
This PR hardens the PE Intelligence Kit to ensure it is investor-relevant without overclaiming or mishandling sensitive information. Key changes include:
- Explicit labeling of all sample data, ROI, and financial metrics as simulated.
- Conversion of unsupported productivity claims (e.g., "work of three associates") into qualified design goals or testable hypotheses.
- Comprehensive confidentiality guidance in the implementation guide, covering MNPI, Virtual Data Rooms (VDRs), and counterparty anonymization.
- A new Buyer Setup Checklist to guide investors through secure environment setup and data sanitization.
- Restoration of foundational brand files (`positioning.md`, `site-ia.md`, `mission-control.md`) to maintain project context.

Fixes #44

---
*PR created automatically by Jules for task [10274169492687419979](https://jules.google.com/task/10274169492687419979) started by @dviveiros3*