### PR TITLE
Implement Trinity storefront v0: /trinity lab and product catalog page

### DIFF
--- a/app/trinity/page-client.tsx
+++ b/app/trinity/page-client.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { TrinityHero } from "@/components/trinity/trinity-hero"
+import { TrinityThesis } from "@/components/trinity/trinity-thesis"
+import { TrinityCatalog } from "@/components/trinity/trinity-catalog"
+import { TrinityExhibits } from "@/components/trinity/trinity-exhibits"
+import { TrinityCTA } from "@/components/trinity/trinity-cta"
+import { StickyHeader } from "@/components/sticky-header"
+
+export default function TrinityPage() {
+  const [activeSection, setActiveSection] = useState("trinity")
+
+  const sectionRefs = {
+    hero: useRef<HTMLElement>(null),
+    thesis: useRef<HTMLElement>(null),
+    forge: useRef<HTMLElement>(null),
+    lab: useRef<HTMLElement>(null),
+    cta: useRef<HTMLElement>(null),
+  }
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const sections = Object.entries(sectionRefs)
+      for (let i = sections.length - 1; i >= 0; i--) {
+        const [id, ref] = sections[i]
+        if (ref.current) {
+          const rect = ref.current.getBoundingClientRect()
+          if (rect.top <= window.innerHeight * 0.4) {
+            setActiveSection(id === 'hero' ? 'trinity' : id)
+            break
+          }
+        }
+      }
+    }
+
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
+
+  const scrollToSection = (sectionId: string) => {
+    const element = document.getElementById(sectionId)
+    if (element) {
+      element.scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      })
+      setActiveSection(sectionId === 'hero' ? 'trinity' : sectionId)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900 overflow-x-hidden">
+      <StickyHeader scrollToSection={scrollToSection} activeSection={activeSection} />
+
+      <main>
+        <section id="hero" ref={sectionRefs.hero}>
+          <TrinityHero />
+        </section>
+
+        <section id="thesis" ref={sectionRefs.thesis}>
+          <TrinityThesis />
+        </section>
+
+        <section id="forge" ref={sectionRefs.forge}>
+          <TrinityCatalog />
+        </section>
+
+        <section id="lab" ref={sectionRefs.lab}>
+          <TrinityExhibits />
+        </section>
+
+        <section id="cta" ref={sectionRefs.cta}>
+          <TrinityCTA />
+        </section>
+      </main>
+
+      <footer className="py-12 border-t border-slate-100 bg-slate-50">
+        <div className="max-w-6xl mx-auto px-6 sm:px-8 flex flex-col md:flex-row justify-between items-center gap-6">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-slate-900 rounded-sm flex items-center justify-center text-white font-bold text-sm">
+              T
+            </div>
+            <span className="font-bold tracking-tight text-slate-900">
+              TRINITY LABS
+            </span>
+          </div>
+          <div className="text-slate-400 text-xs font-mono">
+            © {new Date().getFullYear()} Trinity Applied AI Lab. All Rights Reserved.
+          </div>
+          <div className="flex gap-8">
+            <a href="/" className="text-xs font-medium text-slate-500 hover:text-slate-900 transition-colors">
+              Daniel Viveiros
+            </a>
+            <a href="#" className="text-xs font-medium text-slate-500 hover:text-slate-900 transition-colors">
+              Terms
+            </a>
+            <a href="#" className="text-xs font-medium text-slate-500 hover:text-slate-900 transition-colors">
+              Privacy
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/trinity/page.tsx
+++ b/app/trinity/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next"
+import TrinityPage from "./page-client"
+
+export const metadata: Metadata = {
+  title: "Trinity | Applied AI Lab & Product Forge",
+  description: "Trinity is an applied AI lab that converts technical engineering taste into business leverage through high-conviction product builds.",
+  openGraph: {
+    title: "Trinity | Applied AI Lab & Product Forge",
+    description: "Where engineering taste meets business leverage. Browse the Forge or enter the Lab.",
+    type: "website",
+    images: [
+      {
+        url: "/og-trinity.png",
+        width: 1200,
+        height: 630,
+        alt: "Trinity Applied AI Lab",
+      },
+    ],
+  },
+}
+
+export default function Page() {
+  return <TrinityPage />
+}

--- a/app/trinity/page.tsx
+++ b/app/trinity/page.tsx
@@ -8,14 +8,6 @@ export const metadata: Metadata = {
     title: "Trinity | Applied AI Lab & Product Forge",
     description: "Where engineering taste meets business leverage. Browse the Forge or enter the Lab.",
     type: "website",
-    images: [
-      {
-        url: "/og-trinity.png",
-        width: 1200,
-        height: 630,
-        alt: "Trinity Applied AI Lab",
-      },
-    ],
   },
 }
 

--- a/components/sticky-header.tsx
+++ b/components/sticky-header.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { ArrowUpRight, Menu, X } from 'lucide-react'
+import Link from "next/link"
+import { usePathname, useRouter } from "next/navigation"
 
 interface StickyHeaderProps {
   scrollToSection: (sectionId: string) => void
@@ -12,6 +14,8 @@ interface StickyHeaderProps {
 export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const pathname = usePathname()
+  const router = useRouter()
 
   useEffect(() => {
     const handleScroll = () => {
@@ -22,15 +26,23 @@ export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderPro
   }, [])
 
   const navItems = [
-    { id: "impact", label: "Impact" },
-    { id: "services", label: "Services" },
-    { id: "pricing", label: "Pricing" },
-    { id: "faq", label: "FAQ" },
+    { id: "impact", label: "Impact", href: "/#impact" },
+    { id: "services", label: "Services", href: "/#services" },
+    { id: "pricing", label: "Pricing", href: "/#pricing" },
+    { id: "faq", label: "FAQ", href: "/#faq" },
+    { id: "trinity", label: "Trinity", href: "/trinity" },
   ]
 
-  const handleNavClick = (sectionId: string) => {
-    scrollToSection(sectionId)
+  const handleNavClick = (item: { id: string; href: string }) => {
     setIsMobileMenuOpen(false)
+
+    if (pathname === "/" && item.href.startsWith("/#")) {
+      scrollToSection(item.id)
+    } else if (pathname === "/trinity" && item.href === "/trinity") {
+      scrollToSection("hero")
+    } else {
+      router.push(item.href)
+    }
   }
 
   return (
@@ -44,8 +56,8 @@ export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderPro
         transition={{ duration: 0.5 }}
       >
         <div className="max-w-6xl mx-auto px-6 sm:px-8 flex items-center justify-between">
-          <button
-            onClick={() => handleNavClick("hero")}
+          <Link
+            href="/"
             className="flex items-center gap-2 group"
             aria-label="Go to home"
           >
@@ -57,13 +69,13 @@ export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderPro
             }`}>
               Daniel Viveiros
             </span>
-          </button>
+          </Link>
 
           <nav className="hidden md:flex items-center gap-8">
             {navItems.map((item) => (
               <button
                 key={item.id}
-                onClick={() => scrollToSection(item.id)}
+                onClick={() => handleNavClick(item)}
                 className={`text-sm font-medium transition-colors hover:text-slate-900 ${
                   activeSection === item.id ? "text-slate-900" : "text-slate-500"
                 }`}
@@ -75,7 +87,7 @@ export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderPro
 
           <div className="flex items-center gap-3">
             <button
-              onClick={() => scrollToSection("pricing")}
+              onClick={() => handleNavClick({ id: "pricing", href: "/#pricing" })}
               className="flex items-center gap-2 bg-slate-900 hover:bg-slate-800 text-white text-sm font-medium px-4 py-2 rounded-sm transition-colors"
             >
               <span className="hidden sm:inline">Book Call</span>
@@ -108,7 +120,7 @@ export function StickyHeader({ scrollToSection, activeSection }: StickyHeaderPro
               {navItems.map((item) => (
                 <button
                   key={item.id}
-                  onClick={() => handleNavClick(item.id)}
+                  onClick={() => handleNavClick(item)}
                   className={`text-left px-4 py-3 rounded-sm transition-colors ${
                     activeSection === item.id
                       ? "bg-slate-100 text-slate-900 font-medium"

--- a/components/trinity/trinity-catalog.tsx
+++ b/components/trinity/trinity-catalog.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { ArrowRight, Box } from "lucide-react"
+import { productCatalog } from "@/data/trinity"
+
+export function TrinityCatalog() {
+  return (
+    <section id="forge" className="py-24 bg-white">
+      <div className="max-w-6xl mx-auto px-6 sm:px-8">
+        <div className="flex flex-col md:flex-row md:items-end justify-between mb-12 gap-6">
+          <div className="max-w-2xl">
+            <h2 className="text-3xl font-bold tracking-tight text-slate-900 mb-4">The Forge</h2>
+            <p className="text-slate-600">
+              A marketplace for production-ready AI "kits" and workflows. These are not templates; they are operational modules designed to be deployed.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-400 uppercase tracking-widest">
+            <Box className="w-4 h-4" />
+            Product Catalog
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {productCatalog.map((product, index) => (
+            <div
+              key={product.id}
+              className="group border border-slate-200 p-8 rounded-sm hover:border-slate-900 transition-colors flex flex-col h-full"
+            >
+              <div className="flex justify-between items-start mb-6">
+                <div className={`text-[10px] uppercase font-bold tracking-tighter px-2 py-0.5 rounded-full border ${
+                  product.status === 'Available'
+                    ? 'bg-amber-50 text-amber-600 border-amber-200'
+                    : 'bg-slate-50 text-slate-400 border-slate-200'
+                }`}>
+                  {product.status}
+                </div>
+              </div>
+
+              <h3 className="text-xl font-bold text-slate-900 mb-3 group-hover:text-amber-600 transition-colors">
+                {product.title}
+              </h3>
+              <p className="text-slate-600 text-sm mb-6 flex-grow">
+                {product.description}
+              </p>
+
+              <ul className="space-y-3 mb-8">
+                {product.features.map((feature, idx) => (
+                  <li key={idx} className="flex items-center gap-3 text-xs text-slate-500 font-mono">
+                    <div className="w-1 h-1 bg-slate-300 rounded-full"></div>
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+
+              <button className={`flex items-center justify-between w-full p-4 rounded-sm font-medium transition-all ${
+                product.status === 'Available'
+                  ? 'bg-slate-900 text-white hover:bg-slate-800'
+                  : 'bg-slate-100 text-slate-400 cursor-not-allowed'
+              }`}>
+                <span>{product.status === 'Available' ? 'View Details' : 'Coming Soon'}</span>
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/trinity/trinity-cta.tsx
+++ b/components/trinity/trinity-cta.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { ArrowUpRight, Cpu } from "lucide-react"
+
+export function TrinityCTA() {
+  return (
+    <section id="cta" className="py-24 bg-white relative overflow-hidden">
+      <div className="max-w-4xl mx-auto px-6 sm:px-8 relative z-10 text-center">
+        <div
+          className="bg-slate-900 text-white p-12 md:p-20 rounded-sm relative overflow-hidden"
+        >
+          {/* Abstract Grid Overlay */}
+          <div className="absolute inset-0 opacity-10 pointer-events-none"
+               style={{ backgroundImage: 'linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)', backgroundSize: '20px 20px' }}>
+          </div>
+
+          <div className="relative z-10">
+            <div className="inline-flex items-center justify-center w-12 h-12 rounded-sm bg-amber-400 text-slate-900 mb-8">
+              <Cpu className="w-6 h-6" />
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold mb-6 text-white">Need a Custom Forge?</h2>
+            <p className="text-slate-400 text-lg mb-10 max-w-xl mx-auto">
+              We partner with selected companies to build proprietary AI-native systems. From data pipelines to autonomous workflows, we provide the technical leadership to ensure your investment ships.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <button className="flex items-center justify-center gap-2 bg-white text-slate-900 px-8 py-4 rounded-sm font-bold hover:bg-slate-100 transition-colors">
+                Request Implementation
+                <ArrowUpRight className="w-4 h-4" />
+              </button>
+              <button className="flex items-center justify-center gap-2 border border-slate-700 text-white px-8 py-4 rounded-sm font-medium hover:bg-slate-800 transition-colors">
+                View Lab Whitepapers
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/trinity/trinity-exhibits.tsx
+++ b/components/trinity/trinity-exhibits.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { FlaskConical, Terminal } from "lucide-react"
+import { labExhibits } from "@/data/trinity"
+
+export function TrinityExhibits() {
+  return (
+    <section id="lab" className="py-24 bg-slate-900 text-white overflow-hidden relative">
+      {/* Abstract Background Element */}
+      <div className="absolute top-0 right-0 w-1/2 h-full bg-slate-800/50 skew-x-12 translate-x-1/2 -z-0"></div>
+
+      <div className="max-w-6xl mx-auto px-6 sm:px-8 relative z-10">
+        <div className="flex flex-col md:flex-row md:items-end justify-between mb-16 gap-6">
+          <div className="max-w-2xl">
+            <div className="flex items-center gap-2 text-amber-400 text-xs font-bold uppercase tracking-[0.3em] mb-4">
+              <FlaskConical className="w-4 h-4" />
+              The Lab
+            </div>
+            <h2 className="text-3xl md:text-4xl font-bold tracking-tight mb-4 text-white">Active R&D Exhibits</h2>
+            <p className="text-slate-400">
+              Where we pressure-test hypotheses and build experimental primitives. These exhibits showcase the raw engineering behind our products.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {labExhibits.map((exhibit, index) => (
+            <div
+              key={index}
+              className="group bg-slate-800/50 border border-slate-700 p-8 rounded-sm hover:border-amber-400/50 transition-all"
+            >
+              <div className="grid md:grid-cols-[1fr_2fr] gap-8">
+                <div>
+                  <div className="inline-flex items-center gap-2 px-2 py-0.5 rounded-full bg-slate-900 border border-slate-700 text-[10px] font-mono text-amber-400 mb-4">
+                    <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse"></span>
+                    STATUS: {exhibit.status}
+                  </div>
+                  <h3 className="text-xl font-bold mb-4 font-mono text-white">{exhibit.title}</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {exhibit.stack.map((tech, idx) => (
+                      <span key={idx} className="text-[10px] font-mono text-slate-500 bg-slate-900/50 px-2 py-1 border border-slate-800">
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex flex-col justify-center">
+                  <div className="bg-slate-900/50 p-6 rounded-sm border border-slate-800 font-mono text-sm text-slate-400 leading-relaxed relative">
+                    <Terminal className="w-4 h-4 absolute top-4 right-4 text-slate-700" />
+                    <p>{exhibit.description}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-16 text-center">
+          <p className="text-slate-500 text-sm font-mono italic">
+            Interested in the technical setup of these exhibits? Contact for lab access.
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/trinity/trinity-hero.tsx
+++ b/components/trinity/trinity-hero.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { ArrowUpRight } from "lucide-react"
+import { trinityHero } from "@/data/trinity"
+
+export function TrinityHero() {
+  return (
+    <section className="relative pt-32 pb-20 overflow-hidden bg-white">
+      <div className="max-w-6xl mx-auto px-6 sm:px-8 relative z-10">
+        <div className="flex flex-col items-center text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-900 text-white text-[10px] uppercase tracking-widest font-bold mb-8">
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500"></span>
+            </span>
+            {trinityHero.announcement}
+          </div>
+
+          <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold tracking-tight text-slate-900 mb-6 max-w-4xl">
+            {trinityHero.headline}
+          </h1>
+
+          <p className="text-lg md:text-xl text-slate-600 mb-10 max-w-2xl">
+            {trinityHero.subheadline}
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4">
+            <button className="flex items-center justify-center gap-2 bg-slate-900 text-white px-8 py-4 rounded-sm font-medium hover:bg-slate-800 transition-colors group">
+              Browse The Forge
+              <ArrowUpRight className="w-4 h-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+            </button>
+            <button className="flex items-center justify-center gap-2 border border-slate-200 text-slate-600 px-8 py-4 rounded-sm font-medium hover:bg-slate-50 transition-colors">
+              Enter The Lab
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/trinity/trinity-thesis.tsx
+++ b/components/trinity/trinity-thesis.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { Check, X } from "lucide-react"
+import { labThesis } from "@/data/trinity"
+
+export function TrinityThesis() {
+  const positives = labThesis.filter(p => p.type === "positive")
+  const negatives = labThesis.filter(p => p.type === "negative")
+
+  return (
+    <section id="thesis" className="py-24 bg-slate-50 border-y border-slate-200">
+      <div className="max-w-6xl mx-auto px-6 sm:px-8">
+        <div className="grid md:grid-cols-2 gap-16">
+          <div>
+            <h2 className="text-sm font-bold uppercase tracking-widest text-slate-400 mb-8">What Trinity Is</h2>
+            <div className="space-y-8">
+              {positives.map((point, index) => (
+                <div
+                  key={index}
+                  className="flex gap-4"
+                >
+                  <div className="mt-1 flex-shrink-0 w-5 h-5 rounded-full bg-slate-900 flex items-center justify-center text-white">
+                    <Check className="w-3 h-3" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-slate-900 mb-1">{point.title}</h3>
+                    <p className="text-slate-600 text-sm leading-relaxed">{point.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-bold uppercase tracking-widest text-slate-400 mb-8">What Trinity Is Not</h2>
+            <div className="space-y-8">
+              {negatives.map((point, index) => (
+                <div
+                  key={index}
+                  className="flex gap-4"
+                >
+                  <div className="mt-1 flex-shrink-0 w-5 h-5 rounded-full border border-slate-200 flex items-center justify-center text-slate-400">
+                    <X className="w-3 h-3" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-slate-400 mb-1">{point.title}</h3>
+                    <p className="text-slate-500 text-sm leading-relaxed">{point.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/data/trinity.ts
+++ b/data/trinity.ts
@@ -1,0 +1,116 @@
+export interface TrinityHeroContent {
+  headline: string;
+  subheadline: string;
+  announcement: string;
+}
+
+export const trinityHero: TrinityHeroContent = {
+  headline: "Applied AI Lab for High-Conviction Founders",
+  subheadline: "Where technical engineering taste meets business leverage. We build the systems that redefine unit economics.",
+  announcement: "Trinity v0: Now entering public alpha"
+};
+
+export interface ThesisPoint {
+  title: string;
+  description: string;
+  type: "positive" | "negative";
+}
+
+export const labThesis: ThesisPoint[] = [
+  {
+    title: "Proprietary Systems",
+    description: "We architect core product logic and infrastructure, not shallow LLM wrappers.",
+    type: "positive"
+  },
+  {
+    title: "ROI-First R&D",
+    description: "We don't chase AGI; we chase measurable business leverage and revenue impact.",
+    type: "positive"
+  },
+  {
+    title: "Practitioner-Led",
+    description: "Built by operators who have scaled data teams from Series A to exit.",
+    type: "positive"
+  },
+  {
+    title: "Not an LLM Wrapper Factory",
+    description: "We don't build shallow interfaces for generic ChatGPT workflows.",
+    type: "negative"
+  },
+  {
+    title: "Not a 'Prompt Agency'",
+    description: "We focus on data pipelines and production-grade implementation, not just text generation.",
+    type: "negative"
+  },
+  {
+    title: "Not a Research Lab",
+    description: "Our work is grounded in deployment, not theoretical academic exercises.",
+    type: "negative"
+  }
+];
+
+export interface ProductKit {
+  id: string;
+  title: string;
+  description: string;
+  status: "Available" | "In Development" | "Internal Alpha";
+  features: string[];
+}
+
+export const productCatalog: ProductKit[] = [
+  {
+    id: "growth-kit",
+    title: "The Growth Kit",
+    description: "End-to-end AI operating module for founder-led B2B companies.",
+    status: "Available",
+    features: [
+      "Autonomous Content Engine",
+      "Outbound Prospecting System",
+      "ICP & Positioning Precision Skills"
+    ]
+  },
+  {
+    id: "executive-kit",
+    title: "The Executive Kit",
+    description: "Strategic decision-support systems for modern leadership teams.",
+    status: "In Development",
+    features: [
+      "Automated Board Reporting",
+      "Revenue Forecast Modeling",
+      "Decision Documentation Workflows"
+    ]
+  },
+  {
+    id: "pe-intelligence-kit",
+    title: "PE Intelligence Kit",
+    description: "Modernizing portfolio company data stacks for acquisition readiness.",
+    status: "Internal Alpha",
+    features: [
+      "Due Diligence Automation",
+      "Unit Economic Monitoring",
+      "Exit Multiplier Optimization"
+    ]
+  }
+];
+
+export interface LabExhibit {
+  title: string;
+  status: "In-Training" | "Alpha" | "Stable";
+  description: string;
+  stack: string[];
+}
+
+export const labExhibits: LabExhibit[] = [
+  {
+    title: "Project Zero: Autonomous Context Injection",
+    status: "Alpha",
+    description: "Exploring RAG architectures that maintain 99%+ accuracy for complex legal and financial documents.",
+    stack: ["OpenAI", "Pinecone", "LangChain", "Python"]
+  },
+  {
+    title: "Dynamic Pricing Engine v2",
+    status: "In-Training",
+    description: "Real-time elasticity modeling using deep learning for high-volume e-commerce environments.",
+    stack: ["PyTorch", "AWS Sagemaker", "Snowflake"]
+  }
+];


### PR DESCRIPTION
Implemented the first version of the Trinity storefront and applied AI lab page. This includes a new route at `/trinity` with dedicated sections for the lab's thesis, product catalog (The Forge), and active R&D exhibits. The navigation header was also updated to seamlessly handle transitions between the main brand site and the Trinity lab page.

Fixes #30

---
*PR created automatically by Jules for task [6795947670664453939](https://jules.google.com/task/6795947670664453939) started by @dviveiros3*