### PR TITLE
Trinity Catalog Proof-Discipline Polish Pass

### DIFF
--- a/trinity/catalog/README.md
+++ b/trinity/catalog/README.md
@@ -24,9 +24,9 @@ Every asset in this catalog is designed to be:
 
 | Kit | Status | Path |
 | :--- | :--- | :--- |
-| **Growth Kit** | v0 Candidate | [`/trinity/catalog/kits/growth-kit/`](./kits/growth-kit/) |
-| **Executive Kit** | v0.5 Candidate | [`/trinity/catalog/kits/executive-kit/`](./kits/executive-kit/) |
-| **PE Intelligence Kit** | v0.5 Candidate | [`/trinity/catalog/kits/pe-intelligence-kit/`](./kits/pe-intelligence-kit/) |
+| **Growth Kit** | v0 Candidate | [`/trinity/catalog/growth-kit/`](./growth-kit/) |
+| **Executive Kit** | v0.5 Candidate | [`/trinity/catalog/executive-kit/`](./executive-kit/) |
+| **PE Intelligence Kit** | v0.5 Candidate | [`/trinity/catalog/pe-intelligence-kit/`](./pe-intelligence-kit/) |
 
 ---
 

--- a/trinity/catalog/executive-kit/README.md
+++ b/trinity/catalog/executive-kit/README.md
@@ -8,11 +8,11 @@ High-leverage business intelligence for the founder-operator. The Trinity Execut
 - **Fractional COOs/CFOs** looking for a standardized, AI-enhanced reporting engine to deploy across multiple clients.
 - **Chiefs of Staff** tasked with synthesizing cross-departmental data into executive summaries and decision frameworks.
 
-## Outcomes
-- **Decision Speed:** Transition from identifying a problem to having a structured decision memo in a fraction of the time usually required for manual synthesis.
-- **Reporting Consistency:** A reliable weekly cadence of business intelligence that identifies anomalies before they become crises.
-- **Stakeholder Confidence:** Board updates and investor narratives that tie operational metrics to long-term value creation.
-- **Clarity of Action:** Meeting briefs that ensure every high-stakes conversation is prepared, focused, and documented.
+## Target Outcomes
+- **Decision Speed:** Designed to accelerate the transition from identifying a problem to having a structured decision memo by reducing manual synthesis time.
+- **Reporting Consistency:** Aims to provide a reliable weekly cadence of business intelligence to identify operational anomalies early.
+- **Stakeholder Confidence:** Frameworks for board updates and investor narratives that tie operational metrics to long-term value creation.
+- **Clarity of Action:** Meeting briefs designed to ensure high-stakes conversations are prepared, focused, and documented.
 
 ## What's Included
 1.  **Skills (AI Instructions):** Modular system prompts for:

--- a/trinity/catalog/executive-kit/examples/sample-decision-memo.md
+++ b/trinity/catalog/executive-kit/examples/sample-decision-memo.md
@@ -1,4 +1,4 @@
-# Example: Decision Memo
+# Example: Decision Memo (Simulated)
 *Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
 
 **Decision:** Should we sunset the "Basic" plan ($49/mo) to focus exclusively on Mid-Market ($299/mo+)?

--- a/trinity/catalog/executive-kit/examples/sample-weekly-report.md
+++ b/trinity/catalog/executive-kit/examples/sample-weekly-report.md
@@ -1,4 +1,4 @@
-# Example: Weekly Operator Report
+# Example: Weekly Operator Report (Simulated)
 *Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
 
 **Date:** October 27, 2024

--- a/trinity/catalog/executive-kit/sales-page-copy.md
+++ b/trinity/catalog/executive-kit/sales-page-copy.md
@@ -4,7 +4,7 @@
 **Stop "Running" the Business. Start Leading It.**
 
 ## Sub-headline
-Standardize your leadership intelligence with the AI-powered Executive Kit. Turn fragmented data into board-ready narratives and high-stakes decision memos in a fraction of the usual time.
+Standardize your leadership intelligence with the AI-powered Executive Kit. Turn fragmented data into board-ready narratives and high-stakes decision memos while significantly reducing manual synthesis effort.
 
 ---
 
@@ -20,19 +20,19 @@ This is not a dashboard. It's a **Reporting & Decision Engine**. Built on the lo
 ### What You Get:
 - **The Weekly Intelligence Packet:** A synthesized view of your KPIs, wins, and blockers that actually tells you *what to do next*.
 - **The Decision Memo Framework:** Stop making decisions in Slack. Use our AI-enhanced DACI and 1-Way Door frameworks to make choices that stick.
-- **Board-Ready Narratives:** Prepare for your next investor update or board meeting in a fraction of the time, with significantly higher strategic clarity.
+- **Board-Ready Narratives:** Accelerate the preparation of investor updates or board meetings while enhancing strategic clarity through AI-assisted synthesis.
 - **Meeting Preparation on Autopilot:** Never walk into a high-stakes meeting unprepared again.
 
 ## Why Trinity?
 We don't do "generic AI." We do **Applied Leverage**.
 - **No Fluff:** Every output is designed for a business outcome, not just "summarization."
-- **Practitioner-Led:** Built by operators who have led data teams at Series A-C startups.
+- **Practitioner-Led:** Built by operators who have led data teams and scaled self-service analytics to 150+ users.
 - **System-First:** We give you the skills, the workflows, and the implementation guide to make it permanent.
 
-## Qualified Claims
-- **Efficiency:** Significantly reduce the time spent on weekly reporting while increasing output quality.
-- **Clarity:** Eliminate "I didn't know that was a problem" from your leadership syncs.
-- **Documentation:** Create a permanent, searchable record of every major decision and its rationale.
+## Design Goals & Qualified Claims
+- **Efficiency:** Designed to significantly reduce the manual effort required for weekly reporting while maintaining high output quality.
+- **Clarity:** Aims to provide earlier visibility into operational anomalies before they escalate.
+- **Documentation:** Facilitates the creation of a permanent, searchable record of major decisions and their underlying rationale.
 
 ## Call to Action
 **Upgrade Your Executive OS.**

--- a/trinity/catalog/growth-kit/README.md
+++ b/trinity/catalog/growth-kit/README.md
@@ -1,17 +1,17 @@
 # Trinity Growth Kit: AI-Powered Operating Module for Founder-Led B2B
 
 ## Product Promise
-Turn your founder's expertise into a scalable growth engine. The Trinity Growth Kit is not a collection of prompts; it is an **operational operating system** that automates the transition from raw insight to qualified pipeline.
+Turn your founder's expertise into a scalable growth engine. The Trinity Growth Kit is not a collection of prompts; it is an **operational operating system** that streamlines the transition from raw insight to qualified pipeline.
 
 ## Ideal Buyer
 - **Founder-led B2B companies** ($1M–$10M ARR) where the founder is the primary subject matter expert but the bottleneck for marketing and sales.
 - **Lean Growth Teams** looking for high-leverage workflows to scale content and outbound without increasing headcount.
 
-## Outcomes
-- **Consistency:** A weekly content engine that never misses a post, maintaining your brand's authority.
-- **Precision:** AI-driven ICP definition and lead scoring that ensures you only talk to high-intent prospects.
-- **Scale:** Automated outbound drafting that sounds like you, significantly increasing your manual output capacity.
-- **Operational Leverage:** Move from "doing the work" to "reviewing the work."
+## Target Outcomes
+- **Consistency:** A weekly content engine designed to maintain a consistent publishing cadence and brand authority.
+- **Precision:** AI-driven ICP definition and lead scoring aimed at focusing efforts on high-intent prospects.
+- **Scale:** Automated outbound drafting frameworks designed to significantly increase manual output capacity while maintaining founder voice.
+- **Operational Leverage:** Transition from "doing the work" to "reviewing the work."
 
 ## What's Included
 1.  **Skills (AI Instructions):** Modular, high-precision system prompts for ICP definition, positioning, offer generation, lead scoring, content ideation, and outbound drafting.

--- a/trinity/catalog/growth-kit/examples/icp-output-sample.md
+++ b/trinity/catalog/growth-kit/examples/icp-output-sample.md
@@ -1,4 +1,6 @@
-# Sample Output: ICP Definition
+# Sample Output: ICP Definition (Simulated)
+
+*Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
 
 **Input:** "We sell AI-powered sales coaching to Series B B2B SaaS companies."
 

--- a/trinity/catalog/growth-kit/examples/outbound-email-sample.md
+++ b/trinity/catalog/growth-kit/examples/outbound-email-sample.md
@@ -1,4 +1,6 @@
-# Sample Output: Outbound Email Sequence
+# Sample Output: Outbound Email Sequence (Simulated)
+
+*Note: This is a fictional example for illustrative purposes. All data, organizations, and names are hypothetical.*
 
 **Trigger:** Prospect (Head of Sales) just posted on LinkedIn about the difficulty of maintaining "sales quality" during rapid hiring.
 

--- a/trinity/catalog/growth-kit/sales-page-copy.md
+++ b/trinity/catalog/growth-kit/sales-page-copy.md
@@ -15,7 +15,7 @@ We don't just give you the "what"—we give you the "how."
 ### What You Get:
 - **6 Precision AI Skills:** Modular instructions for ICP Definition, Positioning, Offer Design, Lead Scoring, Content Ideation, and Outbound Drafting.
 - **The Weekly Content Engine:** A workflow designed to transform brief founder insights into a consistent stream of high-authority content.
-- **The Outbound Prospecting Engine:** An automated system that finds your best prospects and drafts emails that actually get replies.
+- **The Outbound Prospecting Engine:** A framework for identifying high-intent prospects and drafting personalized outreach designed to increase engagement rates.
 - **Full Implementation Guide:** Step-by-step instructions to set this up in ChatGPT, Claude, Make, or Zapier.
 
 ### Why It’s Different:
@@ -23,10 +23,10 @@ We don't just give you the "what"—we give you the "how."
 - **Logic-First:** We focus on the *reasoning* behind the growth, not just the text generation.
 - **Scalable:** Designed to be run by a junior marketer or VA, with the founder only acting as the final "Quality Filter."
 
-### Outcomes You Can Expect:
-- **Scalable Content Production:** Significantly increase your content throughput without increasing your time spent.
-- **Higher Lead Quality:** Reduce time wasted on "tire kickers" through precise, AI-driven scoring.
-- **Reliable Pipeline:** A system that runs even when you're on vacation or focused on the product.
+### Target Outcomes:
+- **Scalable Content Production:** Designed to significantly increase your content throughput while minimizing additional time investment.
+- **Higher Lead Quality:** Aims to reduce time spent on low-intent prospects through precise, AI-driven scoring frameworks.
+- **Reliable Pipeline:** A systematic approach to pipeline maintenance that continues to function even when the founder is focused on other priorities.
 
 ### Call to Action:
 **[Get the Trinity Growth Kit Now]**

--- a/trinity/catalog/growth-kit/skills/outbound-drafting.md
+++ b/trinity/catalog/growth-kit/skills/outbound-drafting.md
@@ -1,7 +1,7 @@
 # Skill: Outbound Drafting (Hyper-Personalized)
 
 ## Objective
-To draft outbound emails or LinkedIn DMs that look like they took 30 minutes to write but were generated in seconds.
+To draft outbound emails or LinkedIn DMs that maintain high personalization while significantly reducing manual drafting time.
 
 ## System Instructions
 You are a high-performing SDR. Your goal is to draft a 3-step outbound sequence that feels human, relevant, and low-friction.

--- a/trinity/catalog/pe-intelligence-kit/README.md
+++ b/trinity/catalog/pe-intelligence-kit/README.md
@@ -4,12 +4,12 @@
 Standardize and accelerate the "intelligence" phase of the investment lifecycle. This kit provides a structured framework for using Large Language Models to screen targets, extract KPIs from unstructured data, and map AI-driven operational leverage across portfolio companies.
 
 ## Target Buyer
-- **PE Associates & VPs:** Who need to move from raw data to a draft diligence memo in hours, not days.
+- **PE Associates & VPs:** Tasked with accelerating the transition from raw data to a draft diligence memo.
 - **VC Platform & Operations Leads:** Who want to provide "AI-readiness" as a value-add service to portfolio companies.
 - **Portfolio Operations Directors:** Tasked with identifying margin expansion opportunities through automation and AI.
 
-## Outcomes & Design Goals
-- **Compressed Diligence Cycles:** Aimed at accelerating the extraction of risks, opportunities, and KPIs from data rooms and public filings.
+## Target Outcomes & Design Goals
+- **Compressed Diligence Cycles:** Designed to accelerate the extraction of risks, opportunities, and KPIs from data rooms and public filings.
 - **Standardized Investment Memoranda:** Workflows designed to produce consistent, high-quality analysis following professional investment committee (IC) formats.
 - **Portfolio-Wide AI Mapping:** A repeatable process to screen a portfolio for companies with high potential for AI-driven operational leverage.
 - **Foundational Data Hygiene:** A framework for portfolio companies to transition from manual reporting to AI-ready data infrastructure.
@@ -35,11 +35,11 @@ All ROI, time-savings, and financial metrics included in this kit's examples are
 - **Example AI Opportunity Map:** A visualization of where AI can drive value in a typical B2B SaaS asset.
 - **Implementation Guide:** Step-by-step instructions on data handling, sensitive information protocols, and human-in-the-loop review.
 
-## Privacy & Confidentiality Note (Critical)
-The PE Intelligence Kit is designed for professional use within secure, enterprise-grade AI environments.
+## Compliance, Privacy & Confidentiality (Critical)
+The PE Intelligence Kit is an intelligence augmentation tool designed for professional use within secure, enterprise-grade AI environments. It does not provide investment, legal, compliance, or HR advice.
 
 **Strict Guardrails:**
 - **No Public LLMs:** Users are strictly cautioned against uploading non-anonymized, sensitive, or proprietary company data (MNPI) to public AI models.
 - **Enterprise Environments Only:** Only deploy these workflows in privacy-compliant environments (e.g., Azure OpenAI, Private Claude Instances, or AWS Bedrock) where data is not used for model training.
 - **Anonymization First:** All inputs should be sanitized, removing PII and rounding sensitive financial figures, even when using enterprise AI.
-- **Human Oversight:** All AI-generated outputs must undergo rigorous human review and verification before being used for investment decisions.
+- **Professional Judgment:** All AI-generated outputs must undergo rigorous human review and verification by qualified professionals. This tool is intended to support, not replace, professional investment judgment.

--- a/trinity/catalog/pe-intelligence-kit/buyer-setup-checklist.md
+++ b/trinity/catalog/pe-intelligence-kit/buyer-setup-checklist.md
@@ -24,4 +24,4 @@ This checklist ensures your environment and data are properly prepared before de
 - [ ] **Final Compliance Pass:** Ensure all final artifacts adhere to internal guidelines for investment committee materials.
 
 ---
-**Disclaimer:** This checklist is a framework for operational readiness and does not constitute legal or compliance advice.
+**Disclaimer:** This checklist is a framework for operational readiness and does not constitute investment, legal, compliance, or HR advice.

--- a/trinity/catalog/pe-intelligence-kit/implementation-guide.md
+++ b/trinity/catalog/pe-intelligence-kit/implementation-guide.md
@@ -27,4 +27,4 @@ AI-generated diligence materials should **never** be sent to an Investment Commi
 1. **Verification (Primary Source):** Cross-check all extracted KPIs and financial figures against the original source documents (audited financials, tax returns).
 2. **Contextualization:** AI cannot 'know' the reputation of a management team, the nuances of a specific regional market, or the political landscape of a deal. These must be added by the analyst.
 3. **Tone Check:** Ensure the AI hasn't been overly optimistic or pessimistic. Maintain a neutral, professional 'Diligence Tone' as defined by your firm’s standards.
-4. **Compliance Approval:** Ensure final outputs adhere to internal compliance and legal guidelines regarding investment recommendations.
+4. **Compliance Approval:** Ensure final outputs adhere to internal compliance and legal guidelines. Note that Trinity provides intelligence tools, not investment, legal, or compliance advice.

--- a/trinity/catalog/pe-intelligence-kit/sales-page-copy.md
+++ b/trinity/catalog/pe-intelligence-kit/sales-page-copy.md
@@ -3,10 +3,10 @@
 ## The Strategic Edge for Modern Investors
 In a market where deal speed and operational leverage are the primary drivers of alpha, the ability to rapidly process intelligence is no longer optional.
 
-The Trinity PE Intelligence Kit is not a collection of generic prompts. It is a structured framework designed to move investment professionals from "raw data room" to "strategic conviction" in a fraction of the usual time.
+The Trinity PE Intelligence Kit is not a collection of generic prompts. It is a structured framework designed to accelerate the transition from "raw data room" to "strategic conviction" by streamlining the intelligence synthesis process.
 
-## What it Solves
-- **The "Data Room Fog":** Stop drowning in hundreds of PDFs. Use the kit to extract the narrative, the numbers, and the "unknown unknowns" in minutes.
+## Design Goals: What it Solves
+- **The "Data Room Fog":** Designed to reduce the manual burden of processing hundreds of PDFs, facilitating more rapid extraction of narratives, numbers, and critical "unknown unknowns."
 - **The "Generic Diligence" Trap:** Move beyond surface-level observations. Our skills are tuned to probe for the structural risks and AI-driven growth levers that matter to an exit.
 - **Portfolio Stagnation:** Systematically identify which companies in your portfolio are primed for margin expansion through AI, and which ones are at risk of disruption.
 


### PR DESCRIPTION
Tightened sales and documentation copy across the Trinity catalog (Growth, Executive, and PE Intelligence Kits) to align with "proof-discipline" standards. 

Key changes include:
- Qualifying "Outcomes" as "Target Outcomes" or "Design Goals" (e.g., changing "automates" to "streamlines" or "designed to accelerate").
- Removing specific, unverified time-saving metrics (e.g., "in minutes", "hours, not days") in favor of qualified language like "significantly reducing manual synthesis effort".
- Clarifying that Trinity provides intelligence tools and operational frameworks, not professional advice (investment, legal, compliance, or HR).
- Explicitly labeling fictional examples as "Simulated" and adding boilerplate disclaimers to ensure they are not mistaken for real client data.
- Updating practitioner claims to align with Daniel's verified history from the proof inventory (e.g., scaling analytics to 150+ users).
- Fixing relative links in the main catalog README to reflect the current folder structure.

Fixes #58

---
*PR created automatically by Jules for task [15244648753010881526](https://jules.google.com/task/15244648753010881526) started by @dviveiros3*