### PR TITLE
Add Trinity Distribution OS

### DIFF
--- a/trinity/catalog/growth-kit/README.md
+++ b/trinity/catalog/growth-kit/README.md
@@ -16,12 +16,13 @@ Turn your founder's expertise into a scalable growth engine. The Trinity Growth 
 ## What's Included
 1.  **Skills (AI Instructions):** Modular, high-precision system prompts for ICP definition, positioning, offer generation, lead scoring, content ideation, and outbound drafting.
 2.  **Workflows:** End-to-end specifications for a **Weekly Content Engine** and an **Outbound Prospecting Engine**, including triggers, inputs, steps, and QA checks.
-3.  **Implementation Guide:** Step-by-step setup for LLM providers and optional automation (Make/Zapier/n8n).
-4.  **Buyer Setup Checklist:** [Preparation requirements](./buyer-setup-checklist.md) for data, tools, and roles.
-5.  **Compliance & Ethics:** [Legal and ethical guardrails](./compliance-and-ethics.md) for outbound and AI usage.
-6.  **QA Rubric:** A [5-point quality check](./qa-rubric.md) for all AI outputs.
-7.  **Examples:** Realistic sample outputs to benchmark your results.
-8.  **Sales Page Copy:** Ready-to-use copy to communicate the value of this module to your stakeholders or clients.
+3.  **Distribution OS:** A [solopreneur distribution system](./distribution-os.md) for turning expertise into market presence, qualified conversations, and productized offers.
+4.  **Implementation Guide:** Step-by-step setup for LLM providers and optional automation (Make/Zapier/n8n).
+5.  **Buyer Setup Checklist:** [Preparation requirements](./buyer-setup-checklist.md) for data, tools, and roles.
+6.  **Compliance & Ethics:** [Legal and ethical guardrails](./compliance-and-ethics.md) for outbound and AI usage.
+7.  **QA Rubric:** A [5-point quality check](./qa-rubric.md) for all AI outputs.
+8.  **Examples:** Realistic sample outputs to benchmark your results.
+9.  **Sales Page Copy:** Ready-to-use copy to communicate the value of this module to your stakeholders or clients.
 
 ## Operational Leverage, Not Prompts
 This kit is built on the **Trinity Framework**. We don't just give you "prompts." We give you the logic, the sequence, and the QA mechanisms to build a reliable AI-driven growth department.

--- a/trinity/catalog/growth-kit/distribution-os.md
+++ b/trinity/catalog/growth-kit/distribution-os.md
@@ -1,0 +1,208 @@
+# Trinity Distribution OS
+
+## Purpose
+Distribution is the constraint for a solopreneur. The Trinity Growth Kit exists to turn one person's expertise, taste, proof, and relationships into a repeatable market presence that compounds.
+
+This is not "post more content." It is an operating system for becoming known for a specific transformation, attracting the right buyers, and converting attention into conversations, offers, and pipeline.
+
+## Core Belief
+The strongest solopreneur distribution system is built from four loops:
+
+1. **Point of View Loop:** publish a clear market thesis until people associate you with the problem.
+2. **Proof Loop:** show artifacts, experiments, teardown, results, and lessons instead of vague authority.
+3. **Conversation Loop:** turn audience signals into direct conversations with qualified buyers.
+4. **Offer Loop:** convert repeated buyer pain into productized services, kits, audits, and workflows.
+
+AI should compress the manual work inside each loop. It should not replace judgment, taste, proof, or direct market contact.
+
+## Strategic Positioning
+For Trinity, distribution should make Daniel visible as:
+
+- an applied AI operator, not an AI commentator;
+- a builder of AI workflows and implementation systems, not another prompt seller;
+- a founder using Trinity as a public lab to create sellable AI products;
+- a practitioner learning distribution deeply enough to replicate it across companies.
+
+The market should understand the sentence:
+
+> Trinity builds applied AI systems that turn expertise into leverage, pipeline, and operating advantage.
+
+## Channel System
+The Distribution OS uses channels by job, not vanity.
+
+| Channel | Job | Output |
+| --- | --- | --- |
+| LinkedIn | Authority and buyer discovery | 3-5 high-signal posts per week |
+| X / Threads | Ideas, sharp takes, and founder network | 5-10 short posts per week |
+| Newsletter | Owned audience and deeper trust | 1 weekly dispatch |
+| Website | Credibility, product surface, and conversion | Trinity page, kit pages, proof pages |
+| Direct outbound | Conversations with specific buyers | 25-50 targeted touches per week |
+| Partnerships | Borrowed trust and distribution | 2-4 partner conversations per month |
+| Lab exhibits | Proof and differentiation | 1 public experiment per month |
+
+## Weekly Operating Cadence
+
+### Monday: Market Signal
+- Review target buyer list, recent conversations, and industry news.
+- Pick one core weekly theme.
+- Select 20-50 prospects or relationship targets.
+- Update the ICP and offer notes if the market is shifting.
+
+### Tuesday: Point of View
+- Draft the main weekly argument.
+- Produce 2-3 derivative posts.
+- Tie the argument to a concrete Trinity workflow, exhibit, or buyer pain.
+
+### Wednesday: Proof
+- Publish an artifact: teardown, workflow diagram, before/after, lab note, or implementation lesson.
+- Capture screenshots, prompts, architecture notes, and examples for future proof pages.
+
+### Thursday: Conversation
+- Send targeted outbound based on the week's theme.
+- Reply to comments and DMs with a bias toward calls, audits, and collaborations.
+- Log objections and buyer language.
+
+### Friday: Offer Refinement
+- Review content performance, reply quality, call outcomes, and objections.
+- Convert repeated pain into a sharper offer, kit module, or workflow.
+- Feed winning language back into the website and sales copy.
+
+## AI Workflows
+
+### 1. Founder Insight Extractor
+Input:
+- 10-15 minute founder voice note;
+- recent buyer conversations;
+- current offer notes.
+
+Output:
+- 5 market beliefs;
+- 5 contrarian or high-conviction takes;
+- 5 proof opportunities;
+- 5 outbound angles.
+
+Human review:
+- delete anything generic;
+- keep only ideas Daniel would defend in public.
+
+### 2. Distribution Atomizer
+Input:
+- one core essay, lab note, or market thesis.
+
+Output:
+- 3 LinkedIn posts;
+- 5 short-form posts;
+- 1 newsletter draft;
+- 1 website proof block;
+- 3 outbound openers.
+
+Quality bar:
+- every output must preserve the original insight;
+- no generic AI phrasing;
+- no claims stronger than the proof inventory supports.
+
+### 3. Buyer Signal Scanner
+Input:
+- prospect list;
+- company websites;
+- LinkedIn posts;
+- funding/hiring/product signals.
+
+Output:
+- ranked account list;
+- trigger reason;
+- likely pain;
+- relevant Trinity offer;
+- recommended outreach angle.
+
+Quality bar:
+- no fabricated signals;
+- cite the observed trigger;
+- mark weak assumptions explicitly.
+
+### 4. Offer Intelligence Loop
+Input:
+- DMs;
+- calls;
+- comments;
+- objections;
+- lost deals.
+
+Output:
+- recurring pain patterns;
+- exact buyer language;
+- offer gaps;
+- next kit/workflow ideas;
+- copy updates.
+
+Quality bar:
+- separate observed buyer language from AI interpretation;
+- do not treat one person's opinion as market proof.
+
+## Offer Ladder
+Distribution should drive toward a simple product ladder:
+
+| Stage | Offer | Purpose |
+| --- | --- | --- |
+| Free | Lab notes, teardown posts, newsletter | Build trust and taste |
+| Entry | AI Growth Audit | Convert attention into calls |
+| Core | Trinity Growth Kit implementation | Productized service revenue |
+| Premium | Custom AI distribution system | Higher-ticket implementation |
+| Scalable | Templates, prompts, workflows, mini-products | Product revenue |
+
+## Metrics That Matter
+Avoid vanity-only measurement. Track leading indicators tied to market learning and revenue.
+
+| Metric | Why It Matters |
+| --- | --- |
+| Qualified conversations per week | Distribution is working only if it creates buyer access |
+| Reply quality | Better than raw impressions for early-stage positioning |
+| Repeated pain phrases | Source material for offers and product pages |
+| Proof artifacts shipped | Builds durable credibility |
+| Email/newsletter subscribers | Owned distribution |
+| Audit calls booked | First monetization checkpoint |
+| Kit/workflow sales or pilots | Product-market signal |
+
+## Anti-Slop Rules
+- Do not publish generic AI advice.
+- Do not claim outcomes that are not proven.
+- Do not outsource taste to the model.
+- Do not chase every channel equally.
+- Do not confuse content volume with market authority.
+- Do not let automation send outreach that a human would be embarrassed to send.
+
+## 30-Day Sprint
+
+### Week 1: Positioning and Capture
+- Finalize the core Trinity distribution thesis.
+- Create a simple lead capture path.
+- Publish the first lab/proof note.
+- Build the initial list of 100 target buyers/partners.
+
+### Week 2: Content and Conversation
+- Run the Founder Insight Extractor.
+- Publish 5 posts and 1 newsletter.
+- Send 50 targeted outbound touches.
+- Log every reply and objection.
+
+### Week 3: Offer Test
+- Launch an AI Growth Audit offer.
+- Book 3-5 calls if demand exists.
+- Convert call pain into offer copy and kit modules.
+- Publish one teardown or implementation artifact.
+
+### Week 4: Systemize
+- Review what generated qualified conversations.
+- Cut weak channels.
+- Refine the offer ladder.
+- Turn the strongest workflow into a public Trinity exhibit or product page.
+
+## Definition of Success
+The Distribution OS is working when Trinity can reliably produce:
+
+- visible expertise;
+- buyer conversations;
+- proof artifacts;
+- reusable AI workflows;
+- a sharper offer;
+- and a repeatable path from attention to revenue.


### PR DESCRIPTION
## Summary\n- add a Distribution OS artifact for the Growth Kit\n- frame lead generation as a solopreneur distribution system across POV, proof, conversations, and offers\n- link the Distribution OS from the Growth Kit README\n\n## Notes\n- documentation-only; no app/package changes\n- leaves existing local package and raw Trinity backlog files untouched