### PR TITLE
Create Trinity Growth Audit Entry Offer and Storefront Section

### DIFF
--- a/app/trinity/page.tsx
+++ b/app/trinity/page.tsx
@@ -115,18 +115,18 @@ export default function TrinityStorefront() {
               <button onClick={() => scrollToSection("lab")} className="text-sm font-medium text-slate-500 hover:text-slate-900 transition-colors uppercase tracking-widest">The Lab</button>
               <button onClick={() => scrollToSection("forge")} className="text-sm font-medium text-slate-500 hover:text-slate-900 transition-colors uppercase tracking-widest">The Forge</button>
               <button onClick={() => scrollToSection("distribution")} className="text-sm font-medium text-slate-500 hover:text-slate-900 transition-colors uppercase tracking-widest">Distribution</button>
+              <button onClick={() => scrollToSection("growth-audit")} className="text-sm font-medium text-slate-500 hover:text-slate-900 transition-colors uppercase tracking-widest">Audit</button>
               <button onClick={() => scrollToSection("implementation")} className="text-sm font-medium text-slate-500 hover:text-slate-900 transition-colors uppercase tracking-widest">Services</button>
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <a
-              href="https://calendly.com/daniel-viveiros/15min-intro"
-              target="_blank"
+            <button
+              onClick={() => scrollToSection("growth-audit")}
               className="hidden md:flex items-center gap-2 bg-slate-900 text-white px-4 py-2 text-xs font-bold uppercase tracking-widest hover:bg-slate-800 transition-colors"
             >
               Request Audit
               <ArrowUpRight className="w-3 h-3" />
-            </a>
+            </button>
             <button className="md:hidden" onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
               {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
@@ -141,8 +141,9 @@ export default function TrinityStorefront() {
             <button onClick={() => scrollToSection("lab")} className="text-2xl font-bold uppercase tracking-tighter text-left">The Lab</button>
             <button onClick={() => scrollToSection("forge")} className="text-2xl font-bold uppercase tracking-tighter text-left">The Forge</button>
             <button onClick={() => scrollToSection("distribution")} className="text-2xl font-bold uppercase tracking-tighter text-left">Distribution</button>
+            <button onClick={() => scrollToSection("growth-audit")} className="text-2xl font-bold uppercase tracking-tighter text-left">Audit</button>
             <button onClick={() => scrollToSection("implementation")} className="text-2xl font-bold uppercase tracking-tighter text-left">Services</button>
-            <a href="https://calendly.com/daniel-viveiros/15min-intro" target="_blank" className="bg-slate-900 text-white p-4 text-center font-bold uppercase tracking-widest">Request Audit</a>
+            <button onClick={() => scrollToSection("growth-audit")} className="bg-slate-900 text-white p-4 text-center font-bold uppercase tracking-widest">Request Audit</button>
           </div>
         </div>
       )}
@@ -292,7 +293,7 @@ export default function TrinityStorefront() {
                   The Growth Kit is not generic marketing automation. It is a solopreneur distribution system for turning expertise into visible authority, qualified conversations, and productized offers.
                 </p>
                 <button
-                  onClick={() => scrollToSection("implementation")}
+                  onClick={() => scrollToSection("growth-audit")}
                   className="inline-flex items-center gap-2 bg-white text-slate-950 px-6 py-3 text-xs font-bold uppercase tracking-widest hover:bg-slate-200 transition-colors"
                 >
                   Request Growth Audit
@@ -316,6 +317,84 @@ export default function TrinityStorefront() {
                     </div>
                   )
                 })}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Growth Audit Section */}
+        <section id="growth-audit" className="py-24 px-6 bg-white border-b border-slate-200">
+          <div className="max-w-7xl mx-auto">
+            <div className="grid lg:grid-cols-12 gap-12 items-start">
+              <div className="lg:col-span-5 space-y-8">
+                <div className="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-400">// Entry Offer</div>
+                <h2 className="text-4xl lg:text-7xl font-bold tracking-tighter uppercase leading-[0.9]">
+                  AI Growth <br/>
+                  <span className="text-slate-400">Audit</span>
+                </h2>
+                <p className="text-xl text-slate-600 leading-relaxed max-w-lg">
+                  A 1-week high-conviction diagnostic designed to roadmap your Distribution OS and identify the highest-leverage AI workflows for your specific market.
+                </p>
+
+                <div className="space-y-6 pt-4">
+                  <div className="space-y-2">
+                    <div className="text-[10px] font-bold uppercase tracking-widest text-slate-400">The Requirements</div>
+                    <ul className="space-y-2">
+                      {[
+                        "15-minute founder context brief",
+                        "Previous successful content samples",
+                        "Overview of current sales/marketing stack"
+                      ].map(item => (
+                        <li key={item} className="flex items-center gap-2 text-sm text-slate-600">
+                          <div className="w-1.5 h-1.5 bg-slate-900" />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+              <div className="lg:col-span-7 grid md:grid-cols-2 gap-6">
+                {[
+                  {
+                    title: "POV & Thesis Audit",
+                    desc: "A critical review of your market positioning to sharpen it for AI extraction and authority signaling."
+                  },
+                  {
+                    title: "Loop Diagnostic",
+                    desc: "Mapping your Proof, Conversation, and Offer loops to identify and solve the primary bottleneck."
+                  },
+                  {
+                    title: "Custom AI Skill Design",
+                    desc: "Architectural design for your first 2 core AI skills, tailored to your specific voice and market."
+                  },
+                  {
+                    title: "90-Day Roadmap",
+                    desc: "A prioritized sequence for deploying Growth Kit modules, starting with the highest-leverage loop."
+                  }
+                ].map((item, idx) => (
+                  <div key={idx} className="p-8 border border-slate-200 bg-[#fafafa] space-y-4">
+                    <div className="text-xs font-mono text-slate-400">Deliverable_0{idx + 1}</div>
+                    <h3 className="text-xl font-bold uppercase tracking-tight">{item.title}</h3>
+                    <p className="text-sm text-slate-500 leading-relaxed">{item.desc}</p>
+                  </div>
+                ))}
+
+                <div className="md:col-span-2 p-8 bg-slate-900 text-white flex flex-col md:flex-row items-center justify-between gap-8">
+                  <div className="space-y-1">
+                    <div className="text-2xl font-bold uppercase tracking-tight">Ready to Roadmap?</div>
+                    <p className="text-slate-400 text-sm">Start with a 15-minute discovery call.</p>
+                  </div>
+                  <a
+                    href="https://calendly.com/daniel-viveiros/15min-intro"
+                    target="_blank"
+                    className="bg-white text-slate-900 px-8 py-4 font-bold uppercase tracking-widest hover:bg-slate-200 transition-all flex items-center gap-2"
+                  >
+                    Book Call
+                    <ArrowUpRight className="w-4 h-4" />
+                  </a>
+                </div>
               </div>
             </div>
           </div>
@@ -348,9 +427,9 @@ export default function TrinityStorefront() {
                 </ul>
               </div>
               <div className="p-8 lg:p-12 bg-white text-slate-900 space-y-8">
-                <h3 className="text-2xl font-bold uppercase tracking-tight">Request an Audit</h3>
+                <h3 className="text-2xl font-bold uppercase tracking-tight">Systems & Strategy Audit</h3>
                 <p className="text-slate-600 leading-relaxed">
-                  A 2-week deep dive into your operations, data stack, and AI opportunities. You walk away with a clear roadmap for turning AI into leverage.
+                  While the 1-week **AI Growth Audit** focuses on distribution, this 2-week comprehensive engagement is a deep dive into your full operations, data stack, and AI product opportunities.
                 </p>
                 <div className="space-y-4">
                   <a

--- a/trinity/catalog/growth-kit/README.md
+++ b/trinity/catalog/growth-kit/README.md
@@ -3,6 +3,9 @@
 ## Product Promise
 Turn your founder's expertise into a scalable growth engine. The Trinity Growth Kit is not a collection of prompts; it is an **operational operating system** that streamlines the transition from raw insight to qualified pipeline.
 
+## Entry Offer: AI Growth Audit
+Before a full implementation, we recommend starting with the [AI Growth Audit](./growth-audit.md). It is a 1-week diagnostic designed to roadmap your Distribution OS and identify the highest-leverage AI workflows for your specific market.
+
 ## Ideal Buyer
 - **Founder-led B2B companies** ($1M–$10M ARR) where the founder is the primary subject matter expert but the bottleneck for marketing and sales.
 - **Lean Growth Teams** looking for high-leverage workflows to scale content and outbound without increasing headcount.

--- a/trinity/catalog/growth-kit/growth-audit.md
+++ b/trinity/catalog/growth-kit/growth-audit.md
@@ -1,0 +1,30 @@
+# AI Growth Audit: Distribution OS Diagnostic
+
+## Mission
+The AI Growth Audit is a high-conviction entry offer designed to help founders transition from "random acts of content" to a systematic, AI-powered distribution engine. It provides the diagnostic and roadmap required to operationalize the [Trinity Distribution OS](./distribution-os.md).
+
+## Ideal Buyer
+- **The Solo Founder:** Built a great product but has no repeatable way to attract qualified buyers.
+- **The Subject Matter Expert:** Has deep expertise but lacks the time to turn it into visible authority.
+- **The Early-Stage Operator:** Responsible for growth but stuck in manual, unscalable workflows.
+
+## Deliverables
+The audit is a 1-week diagnostic engagement resulting in:
+
+1.  **POV & Thesis Audit:** A critical review of your current market positioning and authority signals. We identify where your "Point of View" is generic and how to sharpen it for AI extraction.
+2.  **Distribution Loop Diagnostic:** Mapping your current "Proof," "Conversation," and "Offer" loops to identify the primary bottleneck (e.g., you have proof but no conversations, or conversations but no offers).
+3.  **Custom AI Skill Design:** Architectural design for your first 2 core AI skills (e.g., Founder Insight Extractor and Outbound Atomizer) tailored to your specific voice and market.
+4.  **90-Day Implementation Roadmap:** A prioritized sequence for deploying the Growth Kit modules, starting with the highest-leverage loop first.
+
+## What the Audit Requires
+To ensure high-conviction outputs, the buyer must provide:
+- **Founder Context:** A 15-minute recorded brief on market thesis and ideal buyer pain.
+- **Asset Access:** Samples of previous successful content, sales decks, or customer success stories.
+- **Tech Stack Review:** Overview of current CRM, LinkedIn usage, and email tools.
+
+## Proof-Safe Promise
+- **What it is:** A diagnostic, architectural design, and implementation roadmap.
+- **What it is NOT:** A guarantee of specific lead counts, revenue figures, or automated "overnight" success. We provide the blueprint; the founder provides the taste and the truth.
+
+## Next Step
+[Book an Audit Discovery Call](https://calendly.com/daniel-viveiros/15min-intro)


### PR DESCRIPTION
This PR introduces the "AI Growth Audit" as a concrete entry offer for the Trinity Growth Kit. 

Key changes:
1. **New Documentation**: Added `trinity/catalog/growth-kit/growth-audit.md` which details the 1-week diagnostic engagement, including deliverables (POV Audit, Loop Diagnostic, Skill Design, Roadmap) and requirements.
2. **Storefront Updates**: 
   - Added a new `#growth-audit` section to `app/trinity/page.tsx`.
   - Updated the navigation bar to include an "Audit" link.
   - Re-routed the "Request Growth Audit" button from the Distribution section to the new audit section.
   - Updated the "Implementation Services" section to clearly differentiate between the 1-week Growth Audit and the 2-week Systems & Strategy Audit.
3. **Brand Discipline**: All new copy adheres to the "proof-safe" promise, using qualified verbs and avoiding unverified guarantees.
4. **Maintenance**: Restored `package-lock.json` and ensured no build artifacts are included in the commit.

Verified via successful build and Playwright visual inspection.

Fixes #68

---
*PR created automatically by Jules for task [9746817380763609816](https://jules.google.com/task/9746817380763609816) started by @dviveiros3*