### PR TITLE
Define Trinity growth distribution sprint

### DIFF
--- a/trinity/distribution/content-backlog.md
+++ b/trinity/distribution/content-backlog.md
@@ -1,0 +1,102 @@
+# Trinity Content Backlog
+
+## Core Thesis Posts
+
+### 1. AI Will Not Save A Founder Who Cannot Distribute
+Angle:
+- AI increases output, but distribution determines whether output matters.
+- The real system is POV, proof, conversations, offers, conversion.
+
+CTA:
+- "Which loop is weakest in your business right now?"
+
+### 2. Prompts Are Not A Business Model
+Angle:
+- Prompts are components.
+- Workflows, QA, buyer context, and review cadence are the product.
+
+CTA:
+- "If you want to see the operating model, I am publishing the Trinity Distribution OS."
+
+### 3. The Audit Should Produce Workflows, Not A Slide Deck
+Angle:
+- Most AI audits end as strategy theater.
+- A useful audit identifies actual workflows, inputs, owners, and proof gates.
+
+CTA:
+- "I am building the Growth Audit as the entry point for this."
+
+### 4. Founder Voice Is A Distribution Asset
+Angle:
+- A founder's taste and judgment should become a system.
+- AI can atomize insight, but it cannot invent taste.
+
+CTA:
+- "The first workflow in the Growth Kit is the Founder Insight Extractor."
+
+### 5. Distribution Has A Supply Chain
+Angle:
+- Insight becomes artifact.
+- Artifact creates conversation.
+- Conversation sharpens offer.
+- Offer funds implementation.
+
+CTA:
+- "Where does your chain break?"
+
+## Proof Artifact Posts
+
+### 1. Distribution OS Diagram
+Artifact:
+- POV -> Proof -> Conversations -> Offers -> Conversion.
+
+Point:
+- This is the operating system behind the Growth Kit.
+
+### 2. Growth Audit Sample Diagnostic
+Artifact:
+- sample diagnostic sections.
+
+Point:
+- The audit is inspectable before a buyer books.
+
+### 3. Buyer Intake Checklist
+Artifact:
+- required founder context, proof assets, channel access, offer details.
+
+Point:
+- Good AI work depends on high-quality inputs.
+
+### 4. Founder Growth Engine Lab Note
+Artifact:
+- lab exhibit summary.
+
+Point:
+- Trinity is testing the workflow publicly before selling it as proven.
+
+## Conversation Starters
+
+- "If you had to pick one: do you have a POV problem, proof problem, conversation problem, offer problem, or conversion problem?"
+- "What is the strongest belief your market does not yet associate with you?"
+- "What proof do you have that buyers cannot inspect yet?"
+- "Where do qualified conversations currently come from?"
+- "What would make an AI growth audit useful instead of performative?"
+
+## Offer Learning Questions
+
+Use these in comments, DMs, or calls:
+
+1. What are you trying to become known for?
+2. Who is the buyer you most want more conversations with?
+3. What proof do you already have but underuse?
+4. What channel has worked even a little?
+5. What part of distribution feels most manual?
+6. What would make an audit worth paying for?
+7. What would make it feel like another useless strategy deck?
+
+## Do Not Publish
+- Generic "top AI tools" posts.
+- Claims that Trinity has generated revenue for clients.
+- Guaranteed lead-generation promises.
+- Long theory posts with no artifact.
+- Anything that sounds like a generic AI agency.

--- a/trinity/distribution/proof-capture-log.md
+++ b/trinity/distribution/proof-capture-log.md
@@ -1,0 +1,32 @@
+# Trinity Proof Capture Log
+
+## Purpose
+This log separates real proof from ideas, samples, and hypotheses. It prevents Trinity from overclaiming while giving us a place to capture useful signal.
+
+## Proof Categories
+
+| Category | Meaning | Public Use |
+| --- | --- | --- |
+| Verified | Confirmed with source evidence | Can be used directly |
+| Observed | Seen in current work but not yet externally validated | Use carefully with context |
+| Anecdotal | Reported by a person or from a conversation | Use as qualitative signal |
+| Simulated | Fictional or sample data | Must be labeled simulated |
+| Hypothesis | Intended outcome or belief to test | Frame as hypothesis |
+
+## Log
+
+| Date | Artifact / Signal | Category | Source | Public Claim Allowed | Next Action |
+| --- | --- | --- | --- | --- | --- |
+| 2026-05-17 | Trinity Distribution OS created | Observed | `trinity/catalog/growth-kit/distribution-os.md` | Trinity has a documented Distribution OS | Surface it in publishing |
+| 2026-05-17 | AI Growth Audit entry offer created | Observed | `trinity/catalog/growth-kit/growth-audit.md` | Trinity has an entry diagnostic offer | Add sample deliverable |
+| 2026-05-17 | Growth Audit sample diagnostic requested | Hypothesis | Issue #71 | Not public until proof-safe sample is merged | Remove fictional verified claims before merge |
+
+## Weekly Review Questions
+- What did we publish?
+- What got replies?
+- What created serious conversations?
+- What proof artifact did we ship?
+- What buyer objection repeated?
+- What claim needs softer language?
+- What can be promoted from hypothesis to observed?
+- What should be removed from the offer?

--- a/trinity/distribution/publishing-cadence.md
+++ b/trinity/distribution/publishing-cadence.md
@@ -1,0 +1,86 @@
+# Trinity Publishing Cadence
+
+## Purpose
+Publishing is not a content chore. It is the public operating layer of the Distribution OS.
+
+The goal is to make Daniel visible for one transformation:
+
+> Applied AI systems that turn founder expertise into leverage, distribution, and operating advantage.
+
+## Two-Week Cadence
+
+### Week 1 Theme
+Distribution is the constraint for founders building with AI.
+
+| Day | Asset | Channel | Purpose |
+| --- | --- | --- | --- |
+| Monday | POV post: "AI will not save a founder who cannot distribute" | LinkedIn / X | Establish thesis |
+| Tuesday | Short post: "Prompts are not a business model. Distribution loops are." | X / LinkedIn | Sharpen category |
+| Wednesday | Proof artifact: Distribution OS diagram or teardown | LinkedIn / Trinity | Show artifact |
+| Thursday | Conversation prompt: "Where does your growth loop break: POV, proof, conversations, offers, or conversion?" | LinkedIn | Generate replies |
+| Friday | Build note: what changed in the Growth Audit this week | LinkedIn / Newsletter | Show iteration |
+
+### Week 2 Theme
+The Growth Audit is the entry point for founder-led distribution systems.
+
+| Day | Asset | Channel | Purpose |
+| --- | --- | --- | --- |
+| Monday | POV post: "A good AI audit should produce workflows, not a slide deck" | LinkedIn | Position offer |
+| Tuesday | Short post: "The audit is not the product. The operating loop is." | X / LinkedIn | Clarify model |
+| Wednesday | Proof artifact: sample Growth Audit diagnostic | LinkedIn / Trinity | Make offer inspectable |
+| Thursday | Conversation prompt: "Send me your current offer and I will tell you which distribution loop is weak" | LinkedIn | Start conversations |
+| Friday | Review note: objections, questions, and offer changes | Newsletter / LinkedIn | Build trust |
+
+## Post Types
+
+### POV Post
+Purpose:
+- make a strong claim Daniel would defend.
+
+Structure:
+1. Claim.
+2. Why most people get it wrong.
+3. Better model.
+4. Trinity artifact or example.
+5. Question or CTA.
+
+### Proof Artifact Post
+Purpose:
+- show work, not vibes.
+
+Examples:
+- audit sample;
+- workflow diagram;
+- teardown;
+- prompt spec;
+- buyer intake checklist;
+- before/after positioning;
+- lab exhibit.
+
+### Conversation Post
+Purpose:
+- create qualified replies.
+
+Rules:
+- Ask about a real pain.
+- Do not ask generic engagement-bait questions.
+- Reply with useful diagnosis.
+- Move serious replies toward an audit call.
+
+### Build Note
+Purpose:
+- show that Trinity is improving weekly.
+
+Structure:
+1. What changed.
+2. Why it changed.
+3. What signal caused the change.
+4. What will be tested next.
+
+## Quality Rules
+- No generic AI news commentary.
+- No "AI is changing everything" posts.
+- No fake metrics.
+- No screenshot without analysis.
+- No publishing a claim that the proof inventory cannot support.
+- Every week must produce at least one reusable proof artifact.

--- a/trinity/distribution/weekly-offer-review.md
+++ b/trinity/distribution/weekly-offer-review.md
@@ -1,0 +1,65 @@
+# Trinity Weekly Offer Review
+
+## Purpose
+The Growth Audit offer should improve every week from market signal. This document is the review ritual.
+
+## Review Cadence
+Every Friday, update this file with:
+
+- published assets;
+- replies and conversations;
+- objections;
+- proof captured;
+- offer copy changes;
+- next week's test.
+
+## Week Template
+
+### Week Of: [YYYY-MM-DD]
+
+**Theme:**
+
+**Assets Published:**
+- [ ] POV post:
+- [ ] Proof artifact:
+- [ ] Conversation post:
+- [ ] Build note:
+
+**Signals Captured:**
+- Qualified conversations:
+- Useful replies:
+- Objections:
+- Exact buyer language:
+
+**Proof Captured:**
+- Verified:
+- Observed:
+- Anecdotal:
+- Simulated:
+- Hypothesis:
+
+**Offer Changes Made:**
+- Headline:
+- Deliverables:
+- CTA:
+- Intake requirements:
+- Proof language:
+
+**Decision:**
+- Keep:
+- Cut:
+- Test next:
+
+## First Review: 2026-05-22
+
+**Theme:**
+Distribution is the constraint for founders building with AI.
+
+**Assets To Publish:**
+- [ ] POV post: AI will not save a founder who cannot distribute.
+- [ ] Proof artifact: Trinity Distribution OS.
+- [ ] Conversation post: Which loop is weakest: POV, proof, conversations, offers, or conversion?
+- [ ] Build note: How the Growth Audit changed this week.
+
+**Expected Learning:**
+Which part of the Distribution OS creates the strongest buyer response.

--- a/trinity/mission-control.md
+++ b/trinity/mission-control.md
@@ -95,6 +95,17 @@ Not v0:
 2. Merge only clean foundation work or hardened product artifacts.
 3. Convert the best Jules outputs into a coherent Trinity v0 bundle.
 4. Push back on anything that weakens the image, overclaims traction, or creates implementation noise.
+5. Keep the next sprint focused on one monetizable loop: Trinity page -> Growth Kit -> Growth Audit -> publishing -> proof capture -> weekly offer improvement.
+
+## Active Sprint
+Current sprint:
+- `trinity/sprints/growth-distribution-sprint.md`
+
+Supporting operating docs:
+- `trinity/distribution/publishing-cadence.md`
+- `trinity/distribution/content-backlog.md`
+- `trinity/distribution/proof-capture-log.md`
+- `trinity/distribution/weekly-offer-review.md`
 
 ## Guiding Standard
 Trinity should feel like a lab with commercial taste: ambitious enough to attract attention, concrete enough to sell, and disciplined enough to be believed.

--- a/trinity/sprints/growth-distribution-sprint.md
+++ b/trinity/sprints/growth-distribution-sprint.md
@@ -1,0 +1,135 @@
+# Trinity Growth Distribution Sprint
+
+## Sprint Objective
+Build one monetizable loop instead of expanding the product idea pile.
+
+The loop:
+
+1. Trinity homepage explains the lab.
+2. Growth Kit explains the Distribution OS.
+3. Growth Audit has a sample deliverable.
+4. Daniel publishes using the system.
+5. Proof is captured and used to improve the offer weekly.
+
+## Strategic Bet
+The fastest path to Trinity becoming real is not more kits. It is using the Growth Kit on Daniel's own market presence, capturing the proof, and turning that proof into a sharper Growth Audit offer.
+
+This is a side project, but the standard is serious: a visible product surface, a clear entry offer, and a weekly distribution cadence that can eventually be replicated for Daniel's own companies or sold to others.
+
+## What Ships In This Sprint
+
+### 1. Trinity Homepage Explains The Lab
+Primary file:
+- `app/trinity/page.tsx`
+
+Definition of done:
+- Visitor understands Trinity is an applied AI lab, not an LLM company.
+- Growth Kit is visibly the wedge.
+- Growth Audit is the primary call to action.
+- Page avoids fake traction, fake customers, fake checkout, and unsupported claims.
+
+### 2. Growth Kit Explains Distribution OS
+Primary files:
+- `trinity/catalog/growth-kit/README.md`
+- `trinity/catalog/growth-kit/distribution-os.md`
+
+Definition of done:
+- Distribution is framed as the founder constraint.
+- The five loops are clear: POV, proof, conversations, offers, conversion.
+- AI is positioned as leverage for judgment, not a replacement for judgment.
+
+### 3. Growth Audit Has A Sample Deliverable
+Primary files:
+- `trinity/catalog/growth-kit/growth-audit.md`
+- `trinity/catalog/growth-kit/examples/growth-audit-artifact-sample.md`
+- `trinity/catalog/growth-kit/growth-audit-intake.md`
+
+Definition of done:
+- A buyer can inspect what the audit produces.
+- Sample data is labeled fictional/simulated.
+- No lead, revenue, or conversion guarantees are stated as facts.
+- The deliverable points naturally to implementation work.
+
+### 4. Publish Using The System
+Primary files:
+- `trinity/distribution/publishing-cadence.md`
+- `trinity/distribution/content-backlog.md`
+
+Definition of done:
+- There is a 2-week publishing schedule.
+- Posts are based on Daniel's actual thesis, Trinity artifacts, and build-in-public proof.
+- Content is designed to create qualified conversations, not vanity attention.
+
+### 5. Capture Proof And Improve Weekly
+Primary files:
+- `trinity/distribution/proof-capture-log.md`
+- `trinity/distribution/weekly-offer-review.md`
+
+Definition of done:
+- We track what was published, what conversations happened, what objections appeared, and what changed in the offer.
+- Proof is separated into verified, observed, anecdotal, simulated, and hypothesis.
+- The Growth Audit offer improves every week from market signals.
+
+## Weekly Operating Rhythm
+
+### Monday: Thesis And Targets
+- Choose one weekly market thesis.
+- Select target buyer segment.
+- Pick 20-50 relationship targets or accounts.
+- Decide which proof artifact will be published.
+
+### Tuesday: Publish POV
+- Publish one strong point-of-view post.
+- Draft two derivative posts.
+- Log comments and DMs.
+
+### Wednesday: Publish Proof
+- Publish a teardown, diagnostic sample, workflow diagram, lab note, or implementation lesson.
+- Add the artifact to the proof capture log.
+
+### Thursday: Start Conversations
+- Send targeted outbound or warm messages.
+- Use buyer-specific context.
+- Log replies, objections, and exact buyer language.
+
+### Friday: Offer Review
+- Review what created signal.
+- Update Growth Audit copy, deliverables, or intake requirements.
+- Decide what to cut next week.
+
+## Sprint Metrics
+
+Track these weekly:
+
+| Metric | Target For Sprint | Notes |
+| --- | --- | --- |
+| POV posts shipped | 4-6 | No generic AI commentary |
+| Proof artifacts shipped | 2 | Must be inspectable |
+| Qualified conversations | 3-5 | Conversation quality beats volume |
+| Offer objections captured | 5+ | Exact buyer language preferred |
+| Growth Audit page improvements | 1/week | Based on signal |
+| New proof entries | 3+ | Label confidence honestly |
+
+## Current Open Gates
+
+### Must Merge Or Fix
+- Growth Audit sample deliverable PR must remove fictional "verified" proof language before merge.
+- Repo hygiene PRs must not block the growth sprint unless they directly affect development.
+
+### Must Not Do
+- Do not create more generic kits during this sprint.
+- Do not add payment/account systems.
+- Do not expand raw `trinity/products` or `trinity/workflows`.
+- Do not publish claims that imply Trinity already has customer outcomes.
+
+## Sprint Success
+The sprint is successful when a serious visitor can:
+
+1. land on `/trinity`;
+2. understand the lab and Growth Kit;
+3. inspect the Distribution OS;
+4. inspect a Growth Audit sample deliverable;
+5. book a conversation;
+6. see Daniel actively publishing proof-driven distribution content.
+
+The point is not to look big. The point is to make the first monetizable loop real.


### PR DESCRIPTION
## Summary
- define the next Trinity sprint around one monetizable loop
- add publishing cadence, content backlog, proof capture log, and weekly offer review
- update mission control to make the Growth Distribution Sprint the active focus

## Why
This prevents Trinity from drifting into a pile of AI product ideas. The sprint forces the loop: Trinity page -> Growth Kit -> Growth Audit -> publishing -> proof capture -> weekly offer improvement.

## Notes
- docs-only
- no app/package/lockfile changes
- preserves existing dirty package and raw Trinity backlog files