### PR TITLE
Link Growth Audit inspection assets

### DIFF
--- a/trinity/catalog/growth-kit/README.md
+++ b/trinity/catalog/growth-kit/README.md
@@ -6,6 +6,10 @@ Turn your founder's expertise into a scalable growth engine. The Trinity Growth 
 ## Entry Offer: AI Growth Audit
 Before a full implementation, we recommend starting with the [AI Growth Audit](./growth-audit.md). It is a 1-week diagnostic designed to roadmap your Distribution OS and identify the highest-leverage AI workflows for your specific market.
 
+Inspection assets:
+- [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md): simulated output showing the shape of the audit deliverable.
+- [Buyer Intake Checklist](./growth-audit-intake.md): required inputs before the audit starts.
+
 ## Ideal Buyer
 - **Founder-led B2B companies** ($1M–$10M ARR) where the founder is the primary subject matter expert but the bottleneck for marketing and sales.
 - **Lean Growth Teams** looking for high-leverage workflows to scale content and outbound without increasing headcount.

--- a/trinity/catalog/growth-kit/growth-audit.md
+++ b/trinity/catalog/growth-kit/growth-audit.md
@@ -9,7 +9,7 @@ The AI Growth Audit is a high-conviction entry offer designed to help founders t
 - **The Early-Stage Operator:** Responsible for growth but stuck in manual, unscalable workflows.
 
 ## Deliverables
-The audit is a 1-week diagnostic engagement resulting in:
+The audit is a 1-week diagnostic engagement. A buyer can inspect the simulated [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md) before booking.
 
 1.  **POV & Thesis Audit:** A critical review of your current market positioning and authority signals. We identify where your "Point of View" is generic and how to sharpen it for AI extraction.
 2.  **Distribution Loop Diagnostic:** Mapping your current "Proof," "Conversation," and "Offer" loops to identify the primary bottleneck (e.g., you have proof but no conversations, or conversations but no offers).
@@ -17,7 +17,7 @@ The audit is a 1-week diagnostic engagement resulting in:
 4.  **90-Day Implementation Roadmap:** A prioritized sequence for deploying the Growth Kit modules, starting with the highest-leverage loop first.
 
 ## What the Audit Requires
-To ensure high-conviction outputs, the buyer must provide:
+To ensure high-conviction outputs, the buyer completes the [Buyer Intake Checklist](./growth-audit-intake.md), including:
 - **Founder Context:** A 15-minute recorded brief on market thesis and ideal buyer pain.
 - **Asset Access:** Samples of previous successful content, sales decks, or customer success stories.
 - **Tech Stack Review:** Overview of current CRM, LinkedIn usage, and email tools.


### PR DESCRIPTION
## Summary
- Link the simulated Growth Audit sample artifact from the Growth Audit overview and Growth Kit README.
- Link the Buyer Intake Checklist from the same buyer-facing docs.
- Keep language proof-safe by labeling the sample as simulated and avoiding new outcome claims.

## Verification
- Reviewed diff for proof-safety language.
- No package files, lockfiles, app routes, or unrelated Trinity catalog files touched.

Closes #76
Closes #71