### PR TITLE
Create next weekly offer review template for Trinity

### DIFF
--- a/trinity/distribution/weekly-offer-review.md
+++ b/trinity/distribution/weekly-offer-review.md
@@ -54,7 +54,8 @@ Every Friday, update this file with:
 
 | Week Ending | Theme | Artifact | Status |
 | --- | --- | --- | --- |
-| 2026-05-22 | Distribution as a founder constraint | [2026-05-22 Review](./weekly-reviews/2026-05-22-review.md) | Planned |
+| 2026-05-22 | Distribution as a founder constraint | [2026-05-22 Review](./weekly-reviews/2026-05-22-review.md) | In Progress |
+| 2026-05-29 | Growth Audit as the entry point | [2026-05-29 Review](./weekly-reviews/2026-05-29-review.md) | Planned |
 
 ## First Review: 2026-05-22 (Summary)
 

--- a/trinity/distribution/weekly-reviews/2026-05-29-review.md
+++ b/trinity/distribution/weekly-reviews/2026-05-29-review.md
@@ -1,0 +1,87 @@
+# Weekly Review: 2026-05-29
+
+## Review Context
+**Week Ending:** 2026-05-29
+**Sprint:** Growth Distribution Sprint (Week 2)
+**Primary Objective:** Position the Growth Audit as the primary entry point for founder-led distribution systems.
+
+---
+
+## 1. Assets Planned
+*These are the intended outputs for the week. Note: Empty fields are acceptable until real market signal exists.*
+
+| Asset Type | Topic / Title | Status | Link / Result |
+| --- | --- | --- | --- |
+| **POV Post** | "A good AI audit should produce workflows, not a slide deck" | [Pending] | [Fill: URL] |
+| **Short Post** | "The audit is not the product. The operating loop is." | [Pending] | [Fill: URL] |
+| **Proof Artifact** | Sample Growth Audit diagnostic (Inspectable) | [Pending] | [Fill: URL] |
+| **Conversation** | "Send me your current offer and I will tell you which distribution loop is weak." | [Pending] | [Fill: URL] |
+| **Review Note** | Week 2 Summary: Objections, questions, and offer changes. | [Pending] | [Fill: URL] |
+
+---
+
+## 2. Signal To Capture
+*Fields to be filled by Daniel/Codex based on market response. Carry forward from Week 1 only if validated signal exists.*
+
+- **Total Qualified Conversations:** [Fill: Count]
+- **Best Performing Hook:** [Fill: Quote/Link]
+- **Strongest Buyer Objection:** [Fill: Quote]
+- **Exact Buyer Language (Nouns/Verbs they used):**
+  - [Fill: Term 1]
+  - [Fill: Term 2]
+
+---
+
+## 3. Conversation Questions
+*Questions to drop into DMs or comment threads to trigger signal for the Growth Audit.*
+
+1. "If you saw a sample AI Growth Audit today, what's the first thing you'd look for: the tech stack or the distribution roadmap?"
+2. "What's the biggest friction point in your current distribution: creating the content or knowing where to point the attention?"
+3. "Are you currently paying for 'AI advice' that doesn't result in a concrete workflow?"
+
+---
+
+## 4. Proof Inventory Update
+*Documenting new proof captured this week. Maintain strict proof discipline.*
+
+| Artifact / Signal | Category | Source | Public Claim Allowed |
+| --- | --- | --- | --- |
+| [New Artifact] | [Category] | [Source File/Link] | [Allowed Claim] |
+
+**Proof Categories Reference:**
+- **Verified:** Confirmed with source evidence (e.g., screenshots, logs).
+- **Observed:** Seen in current internal work but not yet externally validated.
+- **Anecdotal:** Reported in conversations (e.g., "A founder told me...").
+- **Simulated:** Sample data or fictional examples for demonstration.
+- **Hypothesis:** A belief we are testing (e.g., "We believe X will cause Y").
+
+---
+
+## 5. Offer Assumptions to Test
+*Testing the resonance of the Growth Audit positioning.*
+
+1. **Assumption:** Buyers prefer "Workflows" over "Strategy" or "Prompts."
+   - *Test:* Track engagement on the POV post regarding workflows vs traditional strategy.
+2. **Assumption:** An "inspectable sample" is the fastest way to build trust in an AI service.
+   - *Test:* Monitor click-through or mentions of the sample diagnostic artifact.
+3. **Assumption:** Founders are more interested in "Operating Loops" than "One-off Campaigns."
+   - *Test:* Compare replies to "Operating Loop" vs "Campaign" language.
+
+---
+
+## 6. Growth Audit Offer Changes to Consider
+*Refining the offer based on Week 1/2 signals (Hypothesis until signal exists).*
+
+- **Headline:** [Potential Pivot?]
+- **Deliverables:** [Add/Remove based on buyer language?]
+- **CTA:** [Is 'Book a Call' too high friction?]
+- **Intake:** [Does the intake form feel too long?]
+
+---
+
+## 7. Weekly Decision
+*To be completed during the Friday Review. No invented results.*
+
+- **Keep:**
+- **Cut:**
+- **Pivot:**


### PR DESCRIPTION
This PR creates the weekly review artifact for the week of 2026-05-29, following the theme from the Week 2 publishing cadence. It also updates the weekly offer review index to link to the new template and updates the status of the previous week's review. The changes adhere to the Trinity proof discipline and focus on the Growth Audit as the primary entry point.

Fixes #96

---
*PR created automatically by Jules for task [9612823946682822673](https://jules.google.com/task/9612823946682822673) started by @dviveiros3*