### PR TITLE
Disable Vercel automatic deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with `git.deploymentEnabled: false`
- Prevent Vercel Git auto-deployments from burning deployment quota on every push/PR
- Keep manual Vercel deployments available when needed

## Verification
- `npm run build`

## Scope
- Only adds `vercel.json`
- Does not touch package files, lockfiles, app code, or Trinity content
