### PR TITLE
Add Growth Audit target account qualification rubric

### DIFF
--- a/trinity/distribution/growth-audit-target-account-rubric.md
+++ b/trinity/distribution/growth-audit-target-account-rubric.md
@@ -1,0 +1,100 @@
+# Growth Audit: Target Account Qualification Rubric
+
+## Mission
+This rubric ensures Daniel focuses manual outreach on high-conviction accounts where the **AI Growth Audit** provides immediate, obvious value. We prioritize buyers with existing expertise and proof who lack a systematic distribution engine.
+
+---
+
+## 1. Target Segments (Ranked by Fit)
+
+| Rank | Segment | Why they value the Audit |
+| --- | --- | --- |
+| 1 | **Technical Solo-Founder** | High product/technical proof; zero distribution system; high cost of "random acts of content." |
+| 2 | **Subject Matter Expert (SME)** | Deep authority; "Ghost Town" LinkedIn; needs to atomize expertise without losing voice. |
+| 3 | **High-Leverage Operator** | Manages growth/ops for others; drowning in manual work; needs repeatable AI workflows. |
+| 4 | **The "Anti-AI" Professional** | High taste/judgment; skeptical of slop; values the "scaling judgment" wedge. |
+
+---
+
+## 2. Fit Criteria & Disqualifiers
+
+### Ideal Fit Indicators
+- **Real Expertise:** 5+ years in a specific domain or a live, technical product.
+- **Inspectable Proof:** Has case studies, teardowns, Github repos, or customer wins (even if unscaled).
+- **Distribution Bottleneck:** Visible effort (sporadic posting) but no clear "engine" or conversion loop.
+- **Human-in-the-Loop:** Values their reputation; wants to scale their voice, not replace it.
+
+### Hard Disqualifiers (Do Not Outreach)
+- **The "Magic Button" Seeker:** Asks for "automated leads" or "hands-off revenue."
+- **Zero-Proof Identity:** No product, no expertise, no history. Trinity cannot scale nothing.
+- **The Engagement Podder:** Uses pods/bots for vanity metrics; values volume over signal.
+- **Commodity Content Creator:** Focused on "viral" templates rather than domain-specific authority.
+
+---
+
+## 3. Signal Detection (Where to look)
+
+| Channel | What to look for (Positive Signal) | Loop Leak Indication |
+| --- | --- | --- |
+| **LinkedIn** | High-depth posts with low frequency; "Random Acts" of content. | POV Loop / Conversation Loop |
+| **Website** | "Press Release" blog; hidden case studies; vague service pages. | Proof Loop / Offer Loop |
+| **Newsletters** | Consistent deep-dives but no clear CTA or productized entry point. | Offer Loop / Conversion Loop |
+| **Podcasts** | Guest appearances where they share deep POV but don't own the audience. | POV Loop / Conversion Loop |
+| **GitHub** | Highly active repos with zero "marketing" or explanation of the 'why'. | Proof Loop / POV Loop |
+| **Public Artifacts** | Whitepapers, PDFs, or slides that are "trapped" in old formats. | Proof Loop (Atomization) |
+
+---
+
+## 4. Qualification Scoring (0-10 Scale)
+
+Evaluate every account across five dimensions:
+
+| Dimension | Score (0-2) | Criteria |
+| --- | --- | --- |
+| **Expertise** | | 0: Generic; 1: Niche; 2: Deep Domain Authority/Technical Depth. |
+| **Proof** | | 0: None; 1: Anecdotal; 2: Verifiable/Inspectable Artifacts. |
+| **Bottleneck** | | 0: No Effort; 1: Manual/High Effort; 2: "Random Acts" Syndrome. |
+| **Alignment** | | 0: Wants Magic; 1: Open to AI; 2: Values Taste/Judgment. |
+| **Operating Cadence** | | 0: Inactive; 1: Sporadic activity; 2: Consistent but unoptimized (high drag). |
+
+**Score Guide:**
+- **8-10:** High Priority. Deserves custom, deep-research outreach.
+- **5-7:** Warm Lead. Use a template with 1-2 specific observations.
+- **0-4:** Disqualify. Do not spend manual time.
+
+---
+
+## 5. First-Touch Angles by Segment
+
+| Segment | Recommended Angle | Wedge |
+| --- | --- | --- |
+| **Technical Founder** | The "Random Acts" Observation | From features to repeatable POV engine. |
+| **SME** | The "Ghost Town" Authority | Unlocking trapped expertise via AI extraction. |
+| **Operator** | The "Manual Friction" Audit | Replacing manual distribution lifting with workflows. |
+| **Anti-AI Prof.** | The "Scaling Taste" Wedge | AI as leverage for judgment, not a slop generator. |
+
+---
+
+## 6. Signal-to-Loop Leak Mapping
+
+Use these observations to customize the Audit pitch.
+
+| Observed Signal | Likely Loop Leak | Audit Pivot |
+| --- | --- | --- |
+| Posts often, but content is generic "vibes." | **POV Loop** | "Your deep expertise isn't reaching the page." |
+| Mentions wins in comments but never as a post. | **Proof Loop** | "You have the artifacts; you just aren't showing them." |
+| High engagement on posts but "Ghost Town" DMs. | **Conversation Loop** | "You're getting attention, but not qualified signal." |
+| No clear way to buy a "small" piece of their brain. | **Offer Loop** | "You need a productized entry point (like an Audit)." |
+| Same objections appearing in public replies. | **Conversion Loop** | "We can feed those objections back into the offer." |
+
+---
+
+## 7. Proof-Safe Outreach Language
+
+Keep all outreach grounded in Trinity's Proof Discipline.
+
+- **Use Qualified Verbs:** "Designed to identify," "Aims to map," "Framework for," "Intended to."
+- **Avoid Absolute Outcomes:** Never say "Will double your leads" or "Guarantees 10x growth."
+- **Reference the Lab:** "I'm hardening this in the lab," "Looking for an operator's eye test."
+- **Focus on Diagnostic:** The Audit is a "map" or "blueprint," not a "magic pill."
+- **Value Judgment:** "The system scales your taste, it doesn't replace it."


### PR DESCRIPTION
Added a new documentation artifact `trinity/distribution/growth-audit-target-account-rubric.md` to operationalize the Growth Audit outreach process. This rubric helps Daniel Viveiros qualify prospects based on demonstrable expertise and proof, ensuring outreach is sharper and avoids 'random outbound'.

Key sections included:
1. Target segments ranked by fit.
2. Fit criteria and hard disqualifiers (avoiding 'magic button' seekers).
3. Signal detection across LinkedIn, Websites, Newsletters, Podcasts, and GitHub.
4. A 0-10 scoring rubric (Expertise, Proof, Bottleneck, Alignment, Cadence).
5. First-touch angles tailored to each segment.
6. Signal-to-Loop Leak mapping (POV, Proof, Conversations, Offers, Conversion).
7. Proof-safe outreach language guidelines.

This change is docs-only and maintains the lab's strict proof discipline. No application routes or package files were touched. Verified with a successful `pnpm build`.

Fixes #110

---
*PR created automatically by Jules for task [4390055323014217190](https://jules.google.com/task/4390055323014217190) started by @dviveiros3*