### PR TITLE
Add Post-Publication Review Workflow

### DIFF
--- a/trinity/distribution/post-publication-review-workflow.md
+++ b/trinity/distribution/post-publication-review-workflow.md
@@ -1,0 +1,82 @@
+# Post-Publication Review Workflow
+
+## Purpose
+To turn social media activity into operational signal for the Trinity Growth Audit. This workflow ensures that every post Daniel publishes contributes to the "Offer Intelligence Loop" of the [Distribution OS](../catalog/growth-kit/distribution-os.md).
+
+The goal is not vanity engagement; it is identifying bottlenecks, capturing objections, and refining the offer.
+
+---
+
+## 1. The 30-Minute Window: Signal Detection
+**Goal:** Categorize initial engagement and seed the [Conversation Loop](../catalog/growth-kit/distribution-os.md#3-the-conversation-loop).
+
+*   **Categorize Replies:** Use the [Conversation & Signal Capture Guide](./conversation-signal-guide.md) to triage every comment.
+*   **Seed the Loop:** Reply to "Skeptical Operators" and "Potential Buyers" immediately. Acknowledge their point of view to show "Human-in-the-Loop" presence.
+*   **Identify ICPs:** Look at the profiles of those who liked or commented. Are they Founders, SMEs, or Operators?
+*   **Profile View Check:** Note the "People also viewed" or "Company" data on LinkedIn to see if the post is reaching the intended segment.
+
+---
+
+## 2. The 24-Hour Window: Signal Extraction
+**Goal:** Move high-intent signals from the public feed into the [Proof Capture Log](./proof-capture-log.md).
+
+*   **Review "Hidden Buyers":** Look for ICPs who liked the post but didn't comment. These are prime candidates for [Warm Outbound](./week-1-warm-outbound-pack.md).
+*   **DM Outreach:** Reach out to anyone who asked a "how-to" question or expressed a bottleneck. Use the adaptation notes in the [Publishing Packet](./week-1-publishing-packet.md).
+*   **Objection Capture:** If anyone questioned the feasibility or cost, record their *exact phrasing* in the [Objection Bank](./growth-audit-objection-bank.md).
+*   **Log the Artifact:** Record the post performance in the [Proof Capture Log](./proof-capture-log.md) as "Observed" signal.
+
+---
+
+## 3. Engagement Classification & Action
+| Signal Type | Classification | Action |
+| --- | --- | --- |
+| **Generic Like** | Noise | Ignore unless from a high-value ICP. |
+| **ICP Like** | Soft Signal | Use as "permission" for a warm DM (e.g., "Saw you caught the note on [Thesis]...") |
+| **Validation Comment** | Reputation | Acknowledge/Thank. Reinforce the POV. |
+| **Inquiry Comment** | Hard Signal | Answer briefly, then **move to DM** for context. |
+| **Objection Comment** | Intelligence | Respond with a proof-safe answer. Log exact phrasing in Objection Bank. |
+| **Direct Message** | High Intent | Qualify using the [Conversation Rubric](./conversation-signal-guide.md#3-qualification-rubric-when-to-suggest-the-growth-audit). |
+
+---
+
+## 4. When to Move to DM
+Transition from the public thread to a private DM when:
+1.  **Specificity:** The buyer asks how a concept applies to their specific business or offer.
+2.  **Friction:** The buyer raises a complex objection that requires a "Proof-Safe" nuanced response.
+3.  **Intent:** The buyer asks about the "Growth Audit," "Distribution OS," or "Lab Notes."
+4.  **Depth:** The comment thread goes 2+ levels deep. (Rule: Move to DM to maintain a 1-to-1 relationship).
+
+**The Pivot Script:**
+> "That’s a great point about [Specific Detail]. It’s a bit nuanced for a comment thread—mind if I send you a quick DM with how we handle that in the lab?"
+
+---
+
+## 5. Logging Proof Without Inventing Signal
+To maintain Trinity's [Proof Discipline](../brand/proof-discipline.md):
+*   **No Rounding Up:** If 3 people liked a post, do not call it "significant market resonance."
+*   **Exact Phrasing:** Always use the buyer's exact words in the Objection Bank. Do not translate them into "Growth-speak" (e.g., if they say "I don't have time," don't log it as "High CAC").
+*   **Confidence Labels:**
+    *   `Observed`: You saw the engagement happen.
+    *   `Anecdotal`: A single person said it in a DM.
+    *   `Hypothesis`: You *think* the post worked because of the hook, but have no direct buyer confirmation.
+
+---
+
+## 6. Updating Weekly Review Artifacts
+Every Friday, during the [Weekly Offer Review](./weekly-offer-review.md), perform these steps:
+1.  **Pull Top Objections:** Select the 3 most frequent or "loudest" objections from the week.
+2.  **Pull Signal Posts:** Identify which [Publishing Packet](./week-1-publishing-packet.md) post created the most qualified DMs.
+3.  **Update Offer Copy:** If multiple buyers used the same phrase (e.g., "AI Slop"), update the [Growth Audit](../catalog/growth-kit/growth-audit.md) or [Sales Page](../catalog/growth-kit/sales-page-copy.md) to address it directly.
+
+---
+
+## 7. Post-Publication Checklist
+Run this checklist for every post in the [Content Backlog](./content-backlog.md):
+
+- [ ] **30m:** Replied to all initial comments.
+- [ ] **30m:** Checked LinkedIn "Analytics" for initial ICP alignment.
+- [ ] **24h:** Followed up with all "Inquiry" commenters via DM.
+- [ ] **24h:** Checked likes for "Hidden Buyers" and initiated 3+ warm DMs.
+- [ ] **Log:** Captured 1+ exact objection phrase in the [Objection Bank](./growth-audit-objection-bank.md).
+- [ ] **Log:** Updated [Proof Capture Log](./proof-capture-log.md) with the post link and confidence level.
+- [ ] **Review:** Noted which [Distribution OS Loop](../catalog/growth-kit/distribution-os.md) the post targeted and if it hit.

--- a/trinity/distribution/post-publication-review-workflow.md
+++ b/trinity/distribution/post-publication-review-workflow.md
@@ -21,7 +21,7 @@ The goal is not vanity engagement; it is identifying bottlenecks, capturing obje
 **Goal:** Move high-intent signals from the public feed into the [Proof Capture Log](./proof-capture-log.md).
 
 *   **Review "Hidden Buyers":** Look for ICPs who liked the post but didn't comment. These are prime candidates for [Warm Outbound](./week-1-warm-outbound-pack.md).
-*   **DM Outreach:** Reach out to anyone who asked a "how-to" question or expressed a bottleneck. Use the adaptation notes in the [Publishing Packet](./week-1-publishing-packet.md).
+*   **DM Outreach:** Reach out only when someone asked a "how-to" question, expressed a bottleneck, or is a clearly relevant ICP. Use the adaptation notes in the [Publishing Packet](./week-1-publishing-packet.md).
 *   **Objection Capture:** If anyone questioned the feasibility or cost, record their *exact phrasing* in the [Objection Bank](./growth-audit-objection-bank.md).
 *   **Log the Artifact:** Record the post performance in the [Proof Capture Log](./proof-capture-log.md) as "Observed" signal.
 
@@ -31,7 +31,7 @@ The goal is not vanity engagement; it is identifying bottlenecks, capturing obje
 | Signal Type | Classification | Action |
 | --- | --- | --- |
 | **Generic Like** | Noise | Ignore unless from a high-value ICP. |
-| **ICP Like** | Soft Signal | Use as "permission" for a warm DM (e.g., "Saw you caught the note on [Thesis]...") |
+| **ICP Like** | Soft Signal | Consider a warm DM only if there is specific context beyond the like. |
 | **Validation Comment** | Reputation | Acknowledge/Thank. Reinforce the POV. |
 | **Inquiry Comment** | Hard Signal | Answer briefly, then **move to DM** for context. |
 | **Objection Comment** | Intelligence | Respond with a proof-safe answer. Log exact phrasing in Objection Bank. |
@@ -75,8 +75,8 @@ Run this checklist for every post in the [Content Backlog](./content-backlog.md)
 
 - [ ] **30m:** Replied to all initial comments.
 - [ ] **30m:** Checked LinkedIn "Analytics" for initial ICP alignment.
-- [ ] **24h:** Followed up with all "Inquiry" commenters via DM.
-- [ ] **24h:** Checked likes for "Hidden Buyers" and initiated 3+ warm DMs.
-- [ ] **Log:** Captured 1+ exact objection phrase in the [Objection Bank](./growth-audit-objection-bank.md).
+- [ ] **24h:** Followed up with relevant "Inquiry" commenters via DM.
+- [ ] **24h:** Checked likes for "Hidden Buyers" and initiated only context-specific warm DMs.
+- [ ] **Log:** Captured exact objection phrases in the [Objection Bank](./growth-audit-objection-bank.md) only when real objections appeared.
 - [ ] **Log:** Updated [Proof Capture Log](./proof-capture-log.md) with the post link and confidence level.
 - [ ] **Review:** Noted which [Distribution OS Loop](../catalog/growth-kit/distribution-os.md) the post targeted and if it hit.


### PR DESCRIPTION
This PR adds the 'Post-Publication Review Workflow' artifact to the Trinity distribution folder. It provides a structured operational guide for Daniel to process market signals (likes, comments, DMs) following social media posts. The workflow includes 30-minute/24-hour windows, signal classification, DM transition rules, and integration with the Proof Capture Log and Objection Bank, adhering to Trinity's strict proof discipline. No code, configuration, or dependency changes were made.

Fixes #112

---
*PR created automatically by Jules for task [9880063411965343161](https://jules.google.com/task/9880063411965343161) started by @dviveiros3*