### PR TITLE
Create manual 10-account beta outreach worksheet

### DIFF
--- a/trinity/distribution/growth-audit-10-account-outreach-worksheet.md
+++ b/trinity/distribution/growth-audit-10-account-outreach-worksheet.md
@@ -33,7 +33,7 @@ This worksheet is for the manual selection, research, and preparation of the fir
 *Verify these 5 points before sending any message.*
 
 - [ ] **Proof Verification:** Can I point to at least one specific artifact (post, repo, case study, video) they created?
-- [ ] **Loop Leak Identification:** Have I identified which of the 5 loops (POV, Proof, Conv, Offer, Conversion) is their primary bottleneck?
+- [ ] **Loop Leak Identification:** Have I identified which of the 5 loops (POV, Proof, Conversations, Offers, Conversion) is their primary bottleneck?
 - [ ] **Recency Check:** Have they posted or been active in the last 14 days?
 - [ ] **Context Alignment:** Is there a recent post or event I can reference that isn't a generic "I liked your profile"?
 - [ ] **Tone Check:** Does the message sound like one operator talking to another, or does it sound like a "pitch"?

--- a/trinity/distribution/growth-audit-10-account-outreach-worksheet.md
+++ b/trinity/distribution/growth-audit-10-account-outreach-worksheet.md
@@ -1,0 +1,78 @@
+# Growth Audit: 10-Account Beta Outreach Worksheet
+
+## Mission
+This worksheet is for the manual selection, research, and preparation of the first 10 beta outreach targets for the AI Growth Audit. This is high-context, manual work. No scraping or bulk outreach.
+
+---
+
+## 🛑 Proof-Safe Rule: Lead Logging
+**Do not log targets as "leads" in any CRM or master log until there is a real reply or a two-way conversation started.** Until then, they are "Targets" or "Accounts of Interest."
+
+---
+
+## 1. 10-Account Preparation Worksheet
+
+| # | Target Name | Segment | Source | Observed Proof | Likely Loop Leak | Score | First-Touch Angle | Next Action |
+|---|-------------|---------|--------|----------------|------------------|-------|-------------------|-------------|
+| 1 | | | | | | | | |
+| 2 | | | | | | | | |
+| 3 | | | | | | | | |
+| 4 | | | | | | | | |
+| 5 | | | | | | | | |
+| 6 | | | | | | | | |
+| 7 | | | | | | | | |
+| 8 | | | | | | | | |
+| 9 | | | | | | | | |
+| 10 | | | | | | | | |
+
+*See [Target Account Qualification Rubric](./growth-audit-target-account-rubric.md) for scoring (0-10) and segment definitions.*
+
+---
+
+## 2. Pre-Send Research Checklist
+*Verify these 5 points before sending any message.*
+
+- [ ] **Proof Verification:** Can I point to at least one specific artifact (post, repo, case study, video) they created?
+- [ ] **Loop Leak Identification:** Have I identified which of the 5 loops (POV, Proof, Conv, Offer, Conversion) is their primary bottleneck?
+- [ ] **Recency Check:** Have they posted or been active in the last 14 days?
+- [ ] **Context Alignment:** Is there a recent post or event I can reference that isn't a generic "I liked your profile"?
+- [ ] **Tone Check:** Does the message sound like one operator talking to another, or does it sound like a "pitch"?
+
+---
+
+## 3. Personalization Templates (By Segment)
+
+### A. Technical Solo-Founder
+**Angle:** The "Random Acts" Observation
+> "Hey [Name], I’ve been following your work on [Project/Product]. The technical depth in [Specific Artifact] is clear, but it feels like your distribution is still in 'manual lift' mode. I’m hardening a Growth Audit at Trinity designed to turn that depth into a repeatable engine. Would you be open to an eye-test on a sample diagnostic I’m building for founders like you?"
+
+### B. Subject Matter Expert (SME)
+**Angle:** The "Ghost Town" Authority
+> "[Name], your perspective on [Topic] is far ahead of what I’m seeing on the feed, but it feels like the signal is getting lost in the noise. I’m testing a beta for an AI Growth Audit that extracts SME expertise into a distribution system. I’m looking for one more SME to review the roadmap output—interested in seeing what it produces?"
+
+### C. High-Leverage Operator
+**Angle:** The "Manual Friction" Audit
+> "Hey [Name], saw your recent update on [Result]. It’s a great win, but I’m curious if the process of turning those wins into content feels like a treadmill right now. I’m building a 'Distribution OS' to replace that manual friction with AI-assisted workflows. I’d love to send you the visual spec and get an operator’s take on the 'Conversation Loop'."
+
+### D. The "Anti-AI" Professional
+**Angle:** The "Scaling Taste" Wedge
+> "[Name], I've been seeing the same AI slop you've been calling out. It's why I'm building Trinity—to use AI to scale founder *judgment* rather than replace it. I'm running a small beta for a diagnostic (Growth Audit) that focuses on 'Proof' over 'Prompts'. Given your stance, I’d value your skeptical eye on the sample deliverable."
+
+---
+
+## 4. Disqualification Checklist
+*If any of these are true, remove from the 10-account list.*
+
+- [ ] **The "Magic Button" Seeker:** They post about "passive income," "automated wealth," or "1000 leads/day."
+- [ ] **Zero-Proof Identity:** They have no visible history of doing the work they are talking about.
+- [ ] **Engagement Podder:** Their comments are full of "Great post!" and "Thanks for sharing!" from the same 10 people.
+- [ ] **Quantity over Quality:** They prioritize viral reach/vanity metrics over qualified business signal.
+- [ ] **No Expertise:** They are a generalist curator without a specific "Product" or "Domain Depth."
+
+---
+
+## 5. Next Steps After Selection
+1. Research the 10 accounts and fill the worksheet.
+2. Draft the personalized opener for each (using templates as a base).
+3. Send the messages manually (no automation).
+4. Record any replies or objections in the [Objection Bank](./growth-audit-objection-bank.md) and [Proof Capture Log](./proof-capture-log.md).


### PR DESCRIPTION
This PR adds the manual 10-account beta outreach worksheet for the Trinity Growth Audit.

### Changes
- Created `trinity/distribution/growth-audit-10-account-outreach-worksheet.md` as requested.
- The worksheet includes a 10-row table for target selection and preparation.
- Includes a rigorous pre-send research checklist to ensure high-context outreach.
- Provides 4 personalization templates mapped to the target segments defined in the rubric.
- Establishes a strict disqualification checklist to maintain lead quality.
- Implements the "Proof-Safe Rule" regarding lead logging to prevent fake traction reporting.

### Why it matters
This artifact operationalizes the manual, high-context outreach strategy for the Growth Audit beta. It moves the process from "random acts of outreach" to a structured, repeatable, yet personalized system that aligns with Trinity's proof discipline.

### Proof-Safety Notes
- Explicitly forbids logging targets as leads before a real conversation starts.
- Uses grounded, operator-focused language in all templates.
- Avoids outcome guarantees or fake scarcity.

### Verification
- Manual inspection of the markdown file for structure and content.
- Successfully ran `pnpm build` to confirm no adverse effects on the project build.
- Documentation-only change; no code or package files were touched.

Fixes #119

---
*PR created automatically by Jules for task [7023606097119916220](https://jules.google.com/task/7023606097119916220) started by @dviveiros3*