### PR TITLE
Add Growth Audit deliverable walkthrough for skeptical buyers

### DIFF
--- a/trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md
+++ b/trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md
@@ -15,7 +15,7 @@ The AI Growth Audit is not a report to be filed away. It is an operational diagn
 
 ## Who This Is NOT For
 - **The Magic-Button Seeker:** If you are looking for "100% automated leads" without providing your own expertise and taste, this audit will fail.
-- **The Pre-Proof Founder:** If you have no customers, no case studies, and no market thesis, there is no "raw truth" for the audit to weaponize.
+- **The No-Signal Founder:** If you have no market thesis, buyer conversations, proof artifacts, or operating history to inspect, there is not enough raw material for the audit to operationalize.
 
 ---
 

--- a/trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md
+++ b/trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md
@@ -1,0 +1,66 @@
+# AI Growth Audit: Deliverable Walkthrough
+
+## Proof-Safety Note
+This document is a walkthrough for the [Sample Growth Audit Diagnostic](./growth-audit-artifact-sample.md). The sample artifact is a **simulated diagnostic** used to demonstrate the depth and structure of the Trinity AI Growth Audit. It does not represent a real client engagement.
+
+---
+
+## Purpose
+The AI Growth Audit is not a report to be filed away. It is an operational diagnostic and architectural roadmap. This walkthrough helps a serious buyer understand how to inspect the sample artifact and what specific decisions it enables.
+
+## Who This Is For
+- **The Specialized Operator:** You have a proven transformation but your distribution feels like "random acts of content."
+- **The Technical Founder:** You want to systematize your expertise into a repeatable distribution engine without becoming a full-time "creator."
+- **The Skeptical Buyer:** You want to see the specific diagnostic logic before committing to a paid engagement.
+
+## Who This Is NOT For
+- **The Magic-Button Seeker:** If you are looking for "100% automated leads" without providing your own expertise and taste, this audit will fail.
+- **The Pre-Proof Founder:** If you have no customers, no case studies, and no market thesis, there is no "raw truth" for the audit to weaponize.
+
+---
+
+## Section-by-Section Breakdown
+
+### 1. Executive Summary: The Distribution Bottleneck
+**What it is:** A high-conviction identification of the single loop in your [Distribution OS](../distribution-os.md) that is currently stalling your growth.
+**Buyer Decision:** *Which part of my business needs my attention first?* (e.g., Do I need more traffic, or better conversion of the traffic I already have?)
+
+### 2. POV & Thesis Audit
+**What it is:** A critical comparison of your current market language against a high-signal "Point of View." We look for "Commodity Language" (fluff) and identify "Gold Nuggets" (your unique expertise).
+**Buyer Decision:** *Am I saying anything that a buyer would actually remember?* Use this to decide which beliefs to defend in public.
+
+### 3. Distribution OS Mapping
+**What it is:** A diagnostic table scoring your POV, Proof, Conversations, and Offers. It links observed symptoms (e.g., "likes but no DMs") to specific system leaks.
+**Buyer Decision:** *Is my current activity aligned with my bottleneck?* If your "Proof" is strong but "Conversations" are broken, you should stop making more case studies and start fixing your outbound/CTA loop.
+
+### 4. Custom AI Skill Design (Architecture)
+**What it is:** Not just a list of prompts, but an architectural spec for 2-3 custom AI workflows. These are designed to extract your taste and package your proof.
+**Buyer Decision:** *What specific AI systems should I build or buy?* This provides the blueprint for your implementation team or for Trinity to install.
+
+### 5. 90-Day Roadmap
+**What it is:** A prioritized sequence of implementation. It moves from fixing the primary bottleneck to scaling the loops that work.
+**Buyer Decision:** *What does the next quarter of operating look like?* This is your blueprint for team resourcing and time allocation.
+
+---
+
+## Required Buyer Inputs
+An audit is only as strong as the "raw truth" provided. To make the diagnostic actionable, the buyer must provide:
+- **The Founder Tape:** Raw, unpolished voice notes or videos explaining your market thesis.
+- **Proof Inventory:** Actual screenshots, data, or artifacts of the transformation you deliver.
+- **The Signal Log:** Raw buyer language from real DMs, emails, or sales calls (redacted for privacy).
+
+## Failure Modes: What Makes an Audit Weak?
+An audit becomes non-actionable if:
+1. **Garbage In, Garbage Out:** The buyer provides generic marketing summaries instead of raw founder expertise.
+2. **Disconnected from Proof:** The roadmap suggests claims that the buyer cannot actually back up with evidence.
+3. **Over-Automation:** Designing AI workflows for loops that haven't been proven manually first.
+
+---
+
+## From Diagnostic to Implementation
+The Growth Audit is designed to lead into one of three paths without a "hard sell":
+1. **Self-Service:** You take the roadmap and specs and build the workflows internally using your own team.
+2. **The Trinity Growth Kit:** You install the standardized Trinity modules for content, outbound, and proof capture.
+3. **Custom Implementation:** Trinity builds and manages the specific high-leverage workflows identified in the Skill Design section.
+
+The audit's job is to tell you **what** to do and **why**. The implementation path determines **how** it gets done.

--- a/trinity/catalog/growth-kit/growth-audit.md
+++ b/trinity/catalog/growth-kit/growth-audit.md
@@ -9,7 +9,7 @@ The AI Growth Audit is a high-conviction entry offer designed to help founders t
 - **The Early-Stage Operator:** Responsible for growth but stuck in manual, unscalable workflows.
 
 ## Deliverables
-The audit is a 1-week diagnostic engagement. A buyer can inspect the simulated [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md) before booking.
+The audit is a 1-week diagnostic engagement. A buyer can inspect the simulated [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md) and the [Deliverable Walkthrough](./examples/growth-audit-deliverable-walkthrough.md) before booking.
 
 1.  **POV & Thesis Audit:** A critical review of your current market positioning and authority signals. We identify where your "Point of View" is generic and how to sharpen it for AI extraction.
 2.  **Distribution Loop Diagnostic:** Mapping your current "Proof," "Conversation," and "Offer" loops to identify the primary bottleneck (e.g., you have proof but no conversations, or conversations but no offers).


### PR DESCRIPTION
Added a skeptical-buyer walkthrough for the Growth Audit deliverable. This document helps founders understand how to read the sample audit artifact, what decisions each section supports, and the required inputs for a successful diagnostic. It adheres to Trinity's proof-safety mandate and uses concrete, operator-oriented language.

### What Changed
- Created a new walkthrough file: `trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md`.
- Linked the walkthrough from the main Growth Audit page: `trinity/catalog/growth-kit/growth-audit.md`.

### Why It Matters
Helping skeptical buyers inspect the "how" and "why" behind the deliverable builds trust without requiring fake traction. It positions the audit as a serious engineering diagnostic.

### Proof-Safety Notes
- Includes an explicit Proof-Safety Note at the top of the walkthrough.
- Frames the sample as "simulated" and "fictional."
- Avoids outcome guarantees and marketing fluff.

### Verification Performed
- Ran `pnpm build` to ensure no broken links or build errors.
- Manually verified the Markdown structure and tone against the JULES_BRIEF.

### Intentionally Not Touched
- Did not modify `app/trinity/page.tsx` or any other kit files.
- Did not add any external dependencies.

Fixes #124

---
*PR created automatically by Jules for task [8825476343186751594](https://jules.google.com/task/8825476343186751594) started by @dviveiros3*