### PR TITLE
Create AI Growth Audit Paid Beta Offer Sheet

### DIFF
--- a/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
+++ b/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
@@ -1,0 +1,67 @@
+# AI Growth Audit: Paid Beta Offer Sheet
+
+## Overview
+The AI Growth Audit is a high-conviction diagnostic and architectural roadmap designed to move founders from "random acts of content" to a systematic, AI-powered distribution engine. This is a 1-week intensive designed to identify leaks in your [Distribution OS](./distribution-os.md) and provide the blueprint for fixing them.
+
+## The Ideal Buyer
+- **Technical Solo-Founders:** You have a product that works but no repeatable way to attract qualified buyers.
+- **Subject Matter Experts (SMEs):** You have deep domain expertise but lack the operating system to turn it into visible authority.
+- **Early-Stage Operators:** You are responsible for growth but are stuck in manual, unscalable outbound or content workflows.
+
+### This Is NOT For
+- **The "Magic Button" Seeker:** If you want 1,000 leads overnight without providing your own expertise and taste.
+- **The Zero-Proof Founder:** If you have no product, no expertise, and no historical results to build upon.
+- **The Anti-AI Purist:** If you are unwilling to experiment with AI-assisted extraction and atomization.
+
+## The Paid Beta Promise
+We provide a **diagnostic and roadmap**, not a guarantee of leads or revenue.
+- **What it is:** Engineering-grade clarity on your distribution bottlenecks and a 90-day implementation blueprint.
+- **What it is NOT:** A lead-gen agency service or a "set it and forget it" automation tool.
+
+## The 1-Week Audit Timeline
+
+### Phase 1: Before (The Signal Intake)
+Once the audit is booked, the buyer completes the [Intake Checklist](./growth-audit-intake.md). This includes providing the "Founder Tape" (raw voice/video brief) and access to existing proof assets.
+
+### Phase 2: During (The Diagnostic)
+Trinity performs a deep-dive analysis of your current POV, Proof, Conversation, and Offer loops. We identify the primary leak and design the custom AI workflows required to plug it.
+
+### Phase 3: After (The Roadmap Review)
+A 30-minute high-signal review call to walk through the diagnostic report, architectural specs, and the 90-day implementation sequence.
+
+## Concrete Deliverables
+1.  **POV & Thesis Audit:** Mapping your expertise to a defensible market point of view. Identifying "Gold Nuggets" vs. "Commodity Slop."
+2.  **Distribution Loop Diagnostic:** A visual mapping of your 5 loops to identify the single highest-leverage leak.
+3.  **Custom AI Skill Design:** Architectural specs for your first 2 core AI skills (e.g., Founder Insight Extractor, Outbound Atomizer).
+4.  **90-Day Implementation Roadmap:** A prioritized, week-by-week sequence for deploying the Growth Kit modules.
+
+## Buyer Responsibilities & Required Inputs
+To produce a high-conviction roadmap, the buyer must provide:
+- **The Founder Tape:** 15 minutes of raw, unpolished expertise (The Soapbox, The Expensive Problem).
+- **Proof Inventory:** 3-5 existing artifacts (case studies, results, high-signal content).
+- **Signal Log:** Raw buyer language from real DMs or sales calls (redacted for privacy).
+- **Human Judgment:** Review and refinement of the AI-assisted outputs.
+
+## Pricing (Paid Beta)
+As this is a paid beta, pricing is optimized for rapid signal capture and iterative improvement.
+- **Beta Entry Price:** `$[BETA_PRICE_PLACEHOLDER]`
+- **Terms:** Paid upfront. No refunds on diagnostic work. Includes a credit toward full Growth Kit implementation if moved forward within 30 days.
+
+## Implementation Paths
+Post-audit, you choose the speed of implementation:
+1.  **Founder-Led Build:** Use the roadmap and specs to build internally.
+2.  **Trinity Growth Kit:** Install our standardized operating system and workflows.
+3.  **Custom Engagement:** Scope a deeper implementation for complex workflows or team adoption.
+
+## Disqualification Criteria
+We will decline the audit if:
+1. The buyer cannot provide raw founder expertise or proof assets.
+2. The buyer requires guaranteed ROI or revenue outcomes from a diagnostic.
+3. The bottleneck is product-market fit, not distribution systems.
+
+## 5 Sharp Sales-Call Talking Points
+1. **"You don't have a content problem; you have an operating system problem."** (Focus on the system, not the output volume).
+2. **"AI should leverage your judgment, not replace it."** (Positioning AI as an assistant for the founder's "taste").
+3. **"We aren't guessing; we're mapping your distribution engine to find the leak."** (Engineering-grade diagnostic approach).
+4. **"The goal is to turn your expertise into inspectable proof artifacts."** (Moving away from generic "value-add" content).
+5. **"This audit gives you the blueprint; you decide who builds it and how fast."** (Low-friction, high-clarity entry point).

--- a/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
+++ b/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
@@ -43,9 +43,10 @@ To produce a high-conviction roadmap, the buyer must provide:
 - **Human Judgment:** Review and refinement of the AI-assisted outputs.
 
 ## Pricing (Paid Beta)
-As this is a paid beta, pricing is optimized for rapid signal capture and iterative improvement.
+As this is a paid beta, pricing should be set deliberately before outreach and reviewed weekly against buyer signal.
 - **Beta Entry Price:** `$[BETA_PRICE_PLACEHOLDER]`
-- **Terms:** Paid upfront. No refunds on diagnostic work. Includes a credit toward full Growth Kit implementation if moved forward within 30 days.
+- **Terms:** `[PAYMENT_TERMS_PLACEHOLDER]`
+- **Optional implementation credit:** `[IMPLEMENTATION_CREDIT_PLACEHOLDER]`
 
 ## Implementation Paths
 Post-audit, you choose the speed of implementation:

--- a/trinity/catalog/growth-kit/growth-audit.md
+++ b/trinity/catalog/growth-kit/growth-audit.md
@@ -9,7 +9,7 @@ The AI Growth Audit is a high-conviction entry offer designed to help founders t
 - **The Early-Stage Operator:** Responsible for growth but stuck in manual, unscalable workflows.
 
 ## Deliverables
-The audit is a 1-week diagnostic engagement. A buyer can inspect the simulated [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md) and the [Deliverable Walkthrough](./examples/growth-audit-deliverable-walkthrough.md) before booking.
+The audit is a 1-week diagnostic engagement. A buyer can inspect the [Paid Beta Offer Sheet](./growth-audit-paid-beta-offer-sheet.md), the simulated [Sample Diagnostic Artifact](./examples/growth-audit-artifact-sample.md), and the [Deliverable Walkthrough](./examples/growth-audit-deliverable-walkthrough.md) before booking.
 
 1.  **POV & Thesis Audit:** A critical review of your current market positioning and authority signals. We identify where your "Point of View" is generic and how to sharpen it for AI extraction.
 2.  **Distribution Loop Diagnostic:** Mapping your current "Proof," "Conversation," and "Offer" loops to identify the primary bottleneck (e.g., you have proof but no conversations, or conversations but no offers).


### PR DESCRIPTION
This change adds a new file `trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md` which serves as the primary sales enablement tool for the Growth Audit entry wedge. It defines the ideal buyer, disqualification criteria, a diagnostic-and-roadmap promise, and required inputs (Founder Tape, Proof Inventory) while maintaining Trinity's proof-safety standards. It also adds a link to this new file in the existing `trinity/catalog/growth-kit/growth-audit.md` for better discoverability.

Verification performed:
- Manually verified file content and link consistency.
- Ran `pnpm build` successfully after installing dependencies.
- Confirmed adherence to Trinity's proof-safe and "slop-free" guidelines.

Fixes #131

---
*PR created automatically by Jules for task [18370099261057836507](https://jules.google.com/task/18370099261057836507) started by @dviveiros3*