### PR TITLE
Add Growth Audit proof artifact index

### DIFF
--- a/trinity/distribution/growth-audit-proof-artifact-index.md
+++ b/trinity/distribution/growth-audit-proof-artifact-index.md
@@ -1,0 +1,80 @@
+# Growth Audit: Proof Artifact Index
+
+## Purpose
+This index maintains the "Proof Discipline" for the Trinity Growth Audit beta. It categorizes every artifact by its proof level and public-use safety, ensuring that Daniel can share the lab's rigor without implying non-existent traction.
+
+---
+
+## 1. Artifact Index
+
+| Artifact | Path | Status | Proof Category | Public-Use Guidance | CTA Fit |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Growth Audit Intake** | `trinity/catalog/growth-kit/growth-audit-intake.md` | Active | Observed | **Linkable** (Show rigor) | Conversion |
+| **Audit Artifact Sample** | `trinity/catalog/growth-kit/examples/growth-audit-artifact-sample.md` | Active | **Simulated** | **Screenshot-Safe** (Label Simulated) | Proof |
+| **Deliverable Walkthrough** | `trinity/catalog/growth-kit/examples/growth-audit-deliverable-walkthrough.md` | Active | Observed | **Linkable** (Education) | Proof |
+| **10-Account Worksheet** | `trinity/distribution/growth-audit-10-account-outreach-worksheet.md` | Active | Observed | **Screenshot-Safe** (Redact Names) | Conversation |
+| **Beta Conversation Tracker** | `trinity/distribution/growth-audit-beta-conversation-tracker.md` | Active | Observed | **Internal Only** (Confidential) | Offer |
+| **Objection Bank** | `trinity/distribution/growth-audit-objection-bank.md` | Active | Observed | **Screenshot-Safe** (Partial) | Offer |
+| **Proof Capture Log** | `trinity/distribution/proof-capture-log.md` | Active | Observed | **Internal Only** | Proof |
+| **Week 3 Publishing Packet** | `trinity/distribution/week-3-publishing-packet.md` | Active | Observed | **Internal Only** | POV |
+
+---
+
+## 2. Category Definitions & Usage Rules
+
+### A. Public-Facing (Verified or Observed)
+*Artifacts designed to be seen by prospects to build authority.*
+- **Rules:** Must be hosted on the Trinity site or linkable via a clean URL. No internal "TODO" notes.
+- **Safety:** Ensure no PII or confidential company data is visible.
+
+### B. Internal Operating (Observed)
+*The "Engine Room" artifacts that run the beta.*
+- **Rules:** Generally not for public linking.
+- **Safety:** Can be used for "behind the scenes" screenshots if sensitive fields are blurred.
+
+### C. Simulated Sample (Simulated)
+*Mock outputs used to demonstrate value where real proof does not yet exist.*
+- **Rules:** Must be clearly labeled as "Simulated" or "Sample" in the artifact itself.
+- **Safety:** Do not use real company names even in samples.
+
+### D. Future Proof (Hypothesis)
+*Artifacts being drafted for future loops.*
+- **Rules:** Do not share publicly until they reach "Active" status in this index.
+
+---
+
+## 3. Public Claim Guardrails
+
+| If sharing... | Daniel can safely say: | Daniel CANNOT say: |
+| :--- | :--- | :--- |
+| **Intake / Walkthrough** | "This is how we ensure a high-signal diagnostic." | "This is what our clients use to scale." |
+| **10-Account Worksheet** | "We manually research every target to identify loop leaks." | "Our AI finds 10 leads a day for us." |
+| **Objection Bank** | "We log buyer skepticism to sharpen our offer weekly." | "We have a 100% close rate on these objections." |
+| **Artifact Sample** | "Here is an example of the diagnostic output we produce." | "This is a report from a recent $10k engagement." |
+
+---
+
+## 4. Pre-Publication Checklist
+*Run these 5 checks before posting a screenshot or link.*
+
+- [ ] **Label Check:** If it's a sample, is the "Simulated" disclaimer visible in the frame?
+- [ ] **PII/Privacy Check:** Are all names, emails, and sensitive metrics blurred or redacted?
+- [ ] **Path Check:** Does the link lead to a clean, readable version (not a raw code file)?
+- [ ] **Context Check:** Does the caption explain the *system* rather than claiming a *result*?
+- [ ] **Confidence Check:** Does the post language match the Proof Category in this index?
+
+---
+
+## 5. Top 3 Promotion Recommendations (Current Sprint)
+
+1.  **AI Growth Audit Deliverable Walkthrough:**
+    - **Why:** It demystifies the "black box" of AI consulting and shows the specific decisions a buyer gets to make.
+    - **Channel:** LinkedIn (Link in comments) or Trinity Storefront.
+
+2.  **10-Account Outreach Worksheet (Screenshot):**
+    - **Why:** It proves "System over Slop." It shows the manual rigor that goes into high-leverage distribution.
+    - **Channel:** LinkedIn POV post.
+
+3.  **Growth Audit Intake (Readiness Section):**
+    - **Why:** It signals that Trinity is selective and only works with founders who have real expertise/proof.
+    - **Channel:** LinkedIn / X (Conversation starter).


### PR DESCRIPTION
This PR adds a centralized index for Growth Audit beta artifacts to manage proof discipline and public-use safety.

- **What changed:** Created `trinity/distribution/growth-audit-proof-artifact-index.md`.
- **Why it matters:** Establishes a clear operating framework for what can be shared publicly versus kept internal, ensuring Trinity maintains its "proof-safe" promise while showing rigor.
- **Proof-safety notes:** Explicitly maps artifacts to categories like "Observed," "Simulated," and "Internal Only." Includes public claim guardrails and a pre-publication checklist.
- **Verification performed:** Verified file content matches repository state and adheres to brand guidelines. Ran `pnpm build` to confirm no environmental side effects.
- **Intentionally not touched:** Did not edit existing artifacts or application code.

Fixes #133

---
*PR created automatically by Jules for task [16178182587255591773](https://jules.google.com/task/16178182587255591773) started by @dviveiros3*