### PR TITLE
Add AI Growth Audit buyer onboarding checklist

### DIFF
--- a/trinity/catalog/growth-kit/growth-audit-buyer-onboarding.md
+++ b/trinity/catalog/growth-kit/growth-audit-buyer-onboarding.md
@@ -1,0 +1,79 @@
+# AI Growth Audit: Buyer Onboarding Checklist
+
+This document outlines the manual, high-conviction onboarding process for the Trinity AI Growth Audit Paid Beta. We prioritize raw signal and engineering-grade diagnostics over automated "customer portals."
+
+---
+
+## 1. The Handoff: From "Yes" to Kickoff
+Once the [Discovery Call](../../distribution/growth-audit-discovery-call-script.md) concludes with a "Yes," the transition follows this manual sequence:
+
+1. **Daniel sends the Onboarding Brief:** A single DM or email containing the payment link and this checklist.
+2. **Buyer confirms payment:** The audit is officially "booked" once payment is received.
+3. **The "Truth" Window opens:** The 1-week timeline begins the moment the [Intake Checklist](./growth-audit-intake.md) is returned.
+
+## 2. What Daniel Sends (Post-Yes)
+You will receive a single message containing:
+- **Payment Link:** Secure checkout via Stripe (Manual invoice available upon request).
+- **Secure Intake Link:** A private, time-limited link for uploading sensitive assets and the [Founder Tape](./growth-audit-intake.md#4-high-signal-buyer-inputs).
+- **Scheduling Link:** To book your 30-minute Roadmap Review call (exactly 7 days from the kickoff date).
+
+## 3. What the Buyer Returns (Pre-Audit)
+Before the diagnostic begins, the buyer must provide the following "Raw Material":
+- [ ] **Completed Intake Checklist:** All boxes checked in the [Growth Audit Intake](./growth-audit-intake.md).
+- [ ] **The Founder Tape:** 15 minutes of raw, unpolished expertise (Voice or Video).
+- [ ] **Proof Inventory:** 3-5 existing artifacts (case studies, results, or data).
+- [ ] **Redacted Signal Log:** 5-10 screenshots of real buyer language (DMs/Emails).
+
+## 4. The 1-Week Operating Timeline
+We operate on a 7-day sprint to maintain high intensity and focus.
+
+- **Day 0:** Buyer submits all intake assets. Daniel confirms receipt.
+- **Day 1-2: POV & Loop Audit.** Deep-dive into thesis and bottleneck identification.
+- **Day 3-4: AI Skill Architecture.** Designing the custom workflows and extraction logic.
+- **Day 5: Roadmap Construction.** Building the 90-day implementation sequence.
+- **Day 6: Final Review.** Internal QA and artifact preparation.
+- **Day 7: Roadmap Review Call.** 30-minute walkthrough and handoff.
+
+## 5. Artifact Naming & Privacy Rules
+To ensure "Proof-Safety" and privacy, all audit artifacts follow these rules:
+
+- **Redaction First:** Buyers must redact PII (names, personal emails, sensitive financial data) before submission.
+- **Naming Convention:** `[BUYER_CODE]-Growth-Audit-[YYYY-MM-DD]`.
+- **Privacy Tiers:**
+    - *Internal Diagnostic:* Only Daniel/Trinity sees these.
+    - *Public Proof (Optional):* We will never use your data in public "Lab Notes" without explicit, written permission and further anonymization.
+
+## 6. Review-Call Prep
+The 30-minute Roadmap Review is a high-signal session. To prepare:
+- **Review the Diagnostic:** You will receive the report 2 hours before the call. Read the "Executive Summary" and "Bottleneck Identification" sections first.
+- **Prepare Specific Questions:** Focus on the "90-Day Roadmap" and "AI Skill Design."
+- **Identify Implementation Constraints:** Be ready to discuss who will execute the roadmap (internal team vs. Trinity).
+
+## 7. Post-Audit Implementation Options
+The Audit provides the blueprint. You decide the path forward:
+1. **Self-Service:** Take the specs and build internally.
+2. **Trinity Growth Kit:** Purchase the standardized module implementation.
+3. **Custom Build:** Scope a deeper, high-touch engagement with the Lab.
+
+---
+
+## Template: Onboarding Message
+*This is the message Daniel sends immediately after a verbal "Yes" on the discovery call.*
+
+**Subject: Kickoff: AI Growth Audit // [Founder Name]**
+
+[Founder Name],
+
+Great speaking today. I’m looking forward to digging into the [Specific Loop, e.g., POV Loop] for [Company Name].
+
+To get the 1-week clock started, here are the next steps:
+
+1. **Secure Your Slot:** [Link to Stripe/Payment]
+2. **Complete the Intake:** Please review the [Intake Checklist](./growth-audit-intake.md) and upload your **Founder Tape** and **Proof Inventory** here: [Secure Upload Link]
+3. **Book the Review:** Use this link to book our Roadmap Review for 7 days from today: [Calendly Link]
+
+Once I have the Intake assets, I’ll confirm receipt and we’ll move into the diagnostic phase.
+
+Best,
+
+Daniel

--- a/trinity/catalog/growth-kit/growth-audit-buyer-onboarding.md
+++ b/trinity/catalog/growth-kit/growth-audit-buyer-onboarding.md
@@ -7,15 +7,15 @@ This document outlines the manual, high-conviction onboarding process for the Tr
 ## 1. The Handoff: From "Yes" to Kickoff
 Once the [Discovery Call](../../distribution/growth-audit-discovery-call-script.md) concludes with a "Yes," the transition follows this manual sequence:
 
-1. **Daniel sends the Onboarding Brief:** A single DM or email containing the payment link and this checklist.
-2. **Buyer confirms payment:** The audit is officially "booked" once payment is received.
+1. **Daniel sends the Onboarding Brief:** A single DM or email containing payment instructions, intake instructions, and this checklist.
+2. **Buyer confirms terms:** The audit is officially "booked" once payment terms are confirmed.
 3. **The "Truth" Window opens:** The 1-week timeline begins the moment the [Intake Checklist](./growth-audit-intake.md) is returned.
 
 ## 2. What Daniel Sends (Post-Yes)
 You will receive a single message containing:
-- **Payment Link:** Secure checkout via Stripe (Manual invoice available upon request).
-- **Secure Intake Link:** A private, time-limited link for uploading sensitive assets and the [Founder Tape](./growth-audit-intake.md#4-high-signal-buyer-inputs).
-- **Scheduling Link:** To book your 30-minute Roadmap Review call (exactly 7 days from the kickoff date).
+- **Payment Instructions:** `[PAYMENT_INSTRUCTIONS_PLACEHOLDER]`
+- **Intake Instructions:** `[INTAKE_HANDOFF_PLACEHOLDER]` for sharing sensitive assets and the [Founder Tape](./growth-audit-intake.md#4-high-signal-buyer-inputs).
+- **Scheduling Instructions:** `[REVIEW_CALL_SCHEDULING_PLACEHOLDER]` for the 30-minute Roadmap Review call.
 
 ## 3. What the Buyer Returns (Pre-Audit)
 Before the diagnostic begins, the buyer must provide the following "Raw Material":
@@ -68,9 +68,9 @@ Great speaking today. I’m looking forward to digging into the [Specific Loop, 
 
 To get the 1-week clock started, here are the next steps:
 
-1. **Secure Your Slot:** [Link to Stripe/Payment]
-2. **Complete the Intake:** Please review the [Intake Checklist](./growth-audit-intake.md) and upload your **Founder Tape** and **Proof Inventory** here: [Secure Upload Link]
-3. **Book the Review:** Use this link to book our Roadmap Review for 7 days from today: [Calendly Link]
+1. **Confirm Payment Terms:** [Payment Instructions Placeholder]
+2. **Complete the Intake:** Please review the [Intake Checklist](./growth-audit-intake.md) and send your **Founder Tape** and **Proof Inventory** using the intake handoff instructions here: [Intake Handoff Placeholder]
+3. **Schedule the Review:** Use this scheduling instruction for our Roadmap Review: [Review Call Scheduling Placeholder]
 
 Once I have the Intake assets, I’ll confirm receipt and we’ll move into the diagnostic phase.
 

--- a/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
+++ b/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
@@ -21,7 +21,7 @@ We provide a **diagnostic and roadmap**, not a guarantee of leads or revenue.
 ## The 1-Week Audit Timeline
 
 ### Phase 1: Before (The Signal Intake)
-Once the audit is booked, the buyer completes the [Intake Checklist](./growth-audit-intake.md). This includes providing the "Founder Tape" (raw voice/video brief) and access to existing proof assets.
+Once the audit is booked, the buyer follows the [Onboarding Checklist](./growth-audit-buyer-onboarding.md) and completes the [Intake Checklist](./growth-audit-intake.md). This includes providing the "Founder Tape" (raw voice/video brief) and access to existing proof assets.
 
 ### Phase 2: During (The Diagnostic)
 Trinity performs a deep-dive analysis of your current POV, Proof, Conversation, and Offer loops. We identify the primary leak and design the custom AI workflows required to plug it.


### PR DESCRIPTION
This PR adds a premium, manual-first onboarding checklist for the AI Growth Audit paid beta. It covers the handoff from discovery calls, the 1-week diagnostic timeline, intake requirements (Founder Tape, Proof Inventory, Signal Logs), and post-audit implementation options. The checklist is integrated into the existing documentation structure and maintains Trinity's proof-safe and engineering-grade tone.

Fixes #138

---
*PR created automatically by Jules for task [10659197905720274328](https://jules.google.com/task/10659197905720274328) started by @dviveiros3*