### PR TITLE
Add Growth Audit beta decision dashboard

### DIFF
--- a/trinity/distribution/growth-audit-beta-decision-dashboard.md
+++ b/trinity/distribution/growth-audit-beta-decision-dashboard.md
@@ -41,7 +41,7 @@ This dashboard is the command center for the Growth Audit paid beta. It forces D
 ## 3. Proof Label Guardrails
 *What can Daniel safely say publicly this week? Refer to the [Proof Artifact Index](./growth-audit-proof-artifact-index.md) for full guardrails.*
 
-- **Verified:** "X companies paid for this diagnostic." (Only if 1+ payment exists).
+- **Verified:** "A paid diagnostic has been booked." (Only if payment is confirmed and the buyer has approved the level of attribution).
 - **Observed:** "We identified [Specific Leak] in a technical founder's distribution loop."
 - **Anecdotal:** "Founders are telling us they struggle most with [X]."
 - **Simulated:** "Here is a sample of the 90-day roadmap we design." (Must include disclaimer).

--- a/trinity/distribution/growth-audit-beta-decision-dashboard.md
+++ b/trinity/distribution/growth-audit-beta-decision-dashboard.md
@@ -1,0 +1,91 @@
+# Growth Audit: Beta Decision Dashboard
+
+## Mission
+This dashboard is the command center for the Growth Audit paid beta. It forces Daniel to move from "feeling" to "evidence" by aggregating signals from the Distribution OS loops. It reduces decision fatigue by providing clear triggers for offer pivots, pricing changes, and ICP adjustments.
+
+## Core Operational Links
+- **Signal Capture:** [Beta Conversation Tracker](./growth-audit-beta-conversation-tracker.md)
+- **Proof Inventory:** [Proof Artifact Index](./growth-audit-proof-artifact-index.md)
+- **Decision Log:** [Offer-Change Log](./growth-audit-offer-change-log.md)
+- **Pricing Strategy:** [Pricing Test Matrix](./growth-audit-pricing-test-matrix.md)
+- **Objection Reference:** [Objection Bank](./growth-audit-objection-bank.md)
+- **Archive:** [Weekly Offer Review](./weekly-offer-review.md)
+
+---
+
+## 1. Weekly Decision Matrix
+*Use this table to determine the primary action for the upcoming week based on the previous week's evidence.*
+
+| Action | Primary Trigger (Evidence Required) | Secondary Signal |
+| :--- | :--- | :--- |
+| **Continue** | 2+ qualified conversations AND 1+ "Yes/Maybe" decision. | Price friction is low (score 1-2). |
+| **Sharpen** | 3+ qualified conversations but 0 "Yes" decisions. | Consistent objection pattern identified in the [Objection Bank](./growth-audit-objection-bank.md). |
+| **Pause** | 0 qualified conversations after 2 weeks of publishing. | Thesis isn't landing; lack of "Observed" proof artifacts. |
+| **Raise Price** | 3 consecutive "Yes" decisions with Price Friction < 2. | Buyer suggests value exceeds current "Wedge" pricing. |
+| **Change CTA** | High engagement/clicks but 0 DMs/Replies. | The transition from POV to Audit feels "too heavy." |
+| **Change ICP** | Conversations are with "Magic Button" seekers or low-leverage profiles. | Qual score consistently < 3 in the [Tracker](./growth-audit-beta-conversation-tracker.md). |
+
+---
+
+## 2. Evidence Inspection List
+*Before making a decision, inspect these exact fields. Do not rely on memory.*
+
+1.  **Qual Score (Tracker):** Are we talking to the right people (Founders/SMEs)?
+2.  **Price Friction Score (Tracker):** Is price the blocker, or is it the offer clarity?
+3.  **Exact Buyer Language (Tracker/Log):** Are they using our nouns/verbs or theirs?
+4.  **Proof Category (Artifact Index):** Do we have "Observed" or "Verified" proof for our current claims?
+5.  **Objection Frequency (Objection Bank):** Is there one objection killing every deal?
+
+---
+
+## 3. Proof Label Guardrails
+*What can Daniel safely say publicly this week? Refer to the [Proof Artifact Index](./growth-audit-proof-artifact-index.md) for full guardrails.*
+
+- **Verified:** "X companies paid for this diagnostic." (Only if 1+ payment exists).
+- **Observed:** "We identified [Specific Leak] in a technical founder's distribution loop."
+- **Anecdotal:** "Founders are telling us they struggle most with [X]."
+- **Simulated:** "Here is a sample of the 90-day roadmap we design." (Must include disclaimer).
+- **Hypothesis:** "We believe AI-assisted outreach can reduce research time by [X]%." (Never state as fact).
+
+---
+
+## 4. Friday 20-Minute Review Sequence
+*The operator's ritual. No fluff, just decisions.*
+
+1.  **Minute 0-5: Audit the Tracker.** Open the [Beta Conversation Tracker](./growth-audit-beta-conversation-tracker.md). Sum up Total vs Qualified conversations.
+2.  **Minute 5-10: Identify the Bottleneck.** Which Distribution OS loop leaked the most? (POV, Proof, Conversations, Offer, or Conversion).
+3.  **Minute 10-15: Apply the Matrix.** Match the week's evidence to an action in the Decision Matrix (Section 1).
+4.  **Minute 15-20: Update the Log.** Record the decision and the "Next Week's Test" in the [Offer-Change Log](./growth-audit-offer-change-log.md).
+
+---
+
+## 5. Current Week Dashboard Template
+*Copy this section into a new [Weekly Review](./weekly-reviews/) file each Friday.*
+
+### Week Ending: [YYYY-MM-DD]
+
+### The Signal
+- **Total Conversations:**
+- **Qualified Conversations (Score 4+):**
+- **Decisions (Yes / Maybe / No):**
+- **Price Friction (Avg 1-5):**
+- **Dominant Objection:**
+
+### The Proof
+- **New Artifacts Shipped:**
+- **Proof Level Promotion:** (e.g., Hypothesis -> Observed)
+
+### The Decision
+- **Matrix Action:** (Continue / Sharpen / Pause / Raise Price / Change CTA / Change ICP)
+- **Rationale:**
+- **Asset to Update:** (Link to specific markdown file)
+
+### Next Week's Test
+- **Hypothesis:**
+- **Success Metric:**
+
+---
+**References:**
+- [JULES_BRIEF.md](../JULES_BRIEF.md)
+- [Growth Distribution Sprint](../sprints/growth-distribution-sprint.md)
+- [Proof Capture Log](./proof-capture-log.md)


### PR DESCRIPTION
### What changed
Created `trinity/distribution/growth-audit-beta-decision-dashboard.md` to serve as the command center for the Growth Audit paid beta.

### Why it matters
Trinity needs to move from "feeling" to "evidence" during the distribution sprint. This dashboard forces Daniel to inspect exact metrics (qual scores, price friction, buyer language) before deciding whether to continue, sharpen, or pivot the offer each week.

### Proof-safety notes
The dashboard enforces strict proof label guardrails (Verified, Observed, Anecdotal, etc.) and uses a blank template for the current week to avoid inventing traction. All triggers are evidence-based.

### Files changed
- `trinity/distribution/growth-audit-beta-decision-dashboard.md`

### Verification performed
- Manually inspected the file to verify all relative links to sibling and parent directories are correct.
- Ran `pnpm build` to ensure the new markdown file does not break the project build.
- Conducted a code review to confirm adherence to "operator-grade" quality standards.

### Intentionally not touched
- Did not modify any application code, package files, or existing trackers.
- Did not add any fake data or metrics.

Fixes #144

---
*PR created automatically by Jules for task [14648040002246045867](https://jules.google.com/task/14648040002246045867) started by @dviveiros3*