### PR TITLE
Create Growth Audit no-fit nurture asset

### DIFF
--- a/trinity/catalog/growth-kit/growth-audit-no-fit-nurture.md
+++ b/trinity/catalog/growth-kit/growth-audit-no-fit-nurture.md
@@ -1,0 +1,75 @@
+# AI Growth Audit: Readiness & No-Fit Nurture
+
+## Overview
+The AI Growth Audit is designed for founders and operators who have already built the raw materials of authority: **Expertise** and **Proof**. If your distribution engine isn't ready for a diagnostic, forcing an audit will result in a roadmap you can't execute.
+
+This document helps you identify why you might not be a fit right now and provides a path to becoming "Audit-Ready."
+
+---
+
+## 1. Why You Might Not Be Ready (Yet)
+
+We decline or defer audits in three primary scenarios. This isn't about exclusivity; it's about commercial discipline and ensuring we don't sell you a "map" to a destination you can't reach yet.
+
+### A. The "Zero-Proof" Founder
+**The Gap:** You have a product or service, but no historical wins, case studies, or verifiable results.
+**Why it matters:** The [Distribution OS](./distribution-os.md) is an accelerator, not a creator. We can't "scale" proof that doesn't exist. AI can package your expertise, but it cannot invent it.
+
+### B. The "Magic Button" Seeker
+**The Gap:** You are looking for a "set it and forget it" system that generates leads without your involvement or expertise.
+**Why it matters:** Trinity's philosophy is "AI as Leverage for Judgment." If you aren't willing to provide the "Founder Tape" or review the outputs for taste, the system will produce high-speed slop that damages your brand.
+
+### C. The "Product-Market Fit" Bottleneck
+**The Gap:** Your primary constraint isn't "how do I reach more people?" but "is what I'm selling actually valuable to the market?"
+**Why it matters:** An audit diagnoses distribution leaks. If the offer itself isn't resonating in 1-on-1 conversations, a distribution system will only help you fail faster and louder.
+
+---
+
+## 2. Audit-Readiness Self-Assessment
+Check these four boxes before booking a diagnostic:
+
+- [ ] **Domain Expertise:** Can you speak for 15 minutes about an "Expensive Problem" in your niche without a script?
+- [ ] **Proof Inventory:** Do you have at least 3 inspectable artifacts (case studies, data sets, technical teardowns) that prove you can solve that problem?
+- [ ] **Manual Signal:** Have you had at least 5-10 manual conversations with potential buyers in the last 30 days?
+- [ ] **Operating Capacity:** Are you (or a team member) ready to spend 2-4 hours a week reviewing and refining AI-assisted distribution outputs?
+
+---
+
+## 3. Three Next Steps (Before You Buy An Audit)
+
+If you aren't a fit today, do these three things to build the foundation for a Distribution OS:
+
+1. **Document One "Gold Nugget" Weekly:** Don't worry about a system yet. Just write down one specific, counter-intuitive insight you shared with a client or peer this week. This builds your **POV Loop**.
+2. **Standardize Your Proof:** Take one successful client outcome and turn it into a 1-page "Artifact of Success." Detail the problem, the specific lever you pulled, and the result. This feeds your **Proof Loop**.
+3. **Run 10 Manual Outreach Experiments:** Use the [10-Account Outreach Worksheet](../../distribution/growth-audit-10-account-outreach-worksheet.md) logic. Research 10 people, find a specific "Loop Leak" in their current presence, and send a helpful, no-pitch DM. This builds your **Conversation Loop**.
+
+---
+
+## 4. Communication Templates
+
+### Deferring an Audit (DM/Email)
+> "Thanks for the interest in the AI Growth Audit, [Name]. I've taken a look at your current setup. To be honest, I don't think the Audit is the right move for you just yet.
+>
+> The Audit is designed to map existing expertise and proof into a system. Since you're still in the [Building Proof / Validating Offer] phase, a diagnostic would be premature.
+>
+> I’d recommend focusing on [Step 1 or 2 above] for the next 4-6 weeks. Once you have those first 3-5 proof artifacts ready, the Audit will be 10x more useful. Sound fair?"
+
+### Declining a "Magic Button" Request
+> "I appreciate you reaching out. To be clear, the Trinity approach isn't about fully automated lead-gen or 'hands-off' revenue. We build systems that scale a founder's judgment, which requires you to be 'in the loop.'
+>
+> If you're looking for a 'set it and forget it' automation tool, we probably aren't the right partner for this stage. If you decide you want to build a system around your specific expertise later on, let's talk then."
+
+---
+
+## 5. The Path Back
+We want you to come back when the timing is right.
+
+- **Follow the Lab:** Watch how we publish [Lab Notes](../../lab/README.md) and proof artifacts. This is the "Open Source" version of the system we build in the Audit.
+- **The "Proof Signal":** When you have your first 3 case studies or a clear "Founder Thesis" recorded, reach out. That is the signal that an Audit will now provide a high ROI.
+
+---
+
+## Proof-Safety & Brand Notes
+- **No Shaming:** Not being ready for an audit is a normal stage of business growth, not a failure.
+- **No Fake Scarcity:** We don't decline people because "spots are full"; we decline because the commercial logic doesn't hold up for them yet.
+- **High Status:** Daniel acts as a peer/investigator, not a desperate vendor. Turning down a bad-fit customer protects the brand and the customer's time.

--- a/trinity/catalog/growth-kit/growth-audit-no-fit-nurture.md
+++ b/trinity/catalog/growth-kit/growth-audit-no-fit-nurture.md
@@ -52,7 +52,7 @@ If you aren't a fit today, do these three things to build the foundation for a D
 >
 > The Audit is designed to map existing expertise and proof into a system. Since you're still in the [Building Proof / Validating Offer] phase, a diagnostic would be premature.
 >
-> I’d recommend focusing on [Step 1 or 2 above] for the next 4-6 weeks. Once you have those first 3-5 proof artifacts ready, the Audit will be 10x more useful. Sound fair?"
+> I’d recommend focusing on [Step 1 or 2 above] for the next 4-6 weeks. Once you have those first 3-5 proof artifacts ready, the Audit will have better raw material to work from. Sound fair?"
 
 ### Declining a "Magic Button" Request
 > "I appreciate you reaching out. To be clear, the Trinity approach isn't about fully automated lead-gen or 'hands-off' revenue. We build systems that scale a founder's judgment, which requires you to be 'in the loop.'
@@ -65,7 +65,7 @@ If you aren't a fit today, do these three things to build the foundation for a D
 We want you to come back when the timing is right.
 
 - **Follow the Lab:** Watch how we publish [Lab Notes](../../lab/README.md) and proof artifacts. This is the "Open Source" version of the system we build in the Audit.
-- **The "Proof Signal":** When you have your first 3 case studies or a clear "Founder Thesis" recorded, reach out. That is the signal that an Audit will now provide a high ROI.
+- **The "Proof Signal":** When you have your first 3 case studies or a clear "Founder Thesis" recorded, reach out. That is the signal that an Audit can produce a more specific diagnostic and roadmap.
 
 ---
 

--- a/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
+++ b/trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md
@@ -60,6 +60,8 @@ We will decline the audit if:
 2. The buyer requires guaranteed ROI or revenue outcomes from a diagnostic.
 3. The bottleneck is product-market fit, not distribution systems.
 
+If you aren't sure if you are a fit, review the [Readiness & No-Fit Nurture](./growth-audit-no-fit-nurture.md) guide.
+
 ## 5 Sharp Sales-Call Talking Points
 1. **"You don't have a content problem; you have an operating system problem."** (Focus on the system, not the output volume).
 2. **"AI should leverage your judgment, not replace it."** (Positioning AI as an assistant for the founder's "taste").


### PR DESCRIPTION
This change introduces a "no-fit nurture" asset for the AI Growth Audit. It provides a structured way for Daniel to decline or defer low-fit or early-stage founders while remaining helpful and maintaining brand quality. The asset includes disqualification categories, a self-assessment checklist, practical next steps, and communication templates. It also adds a link to this new guide from the primary Growth Audit offer sheet.

Key changes:
- Created `trinity/catalog/growth-kit/growth-audit-no-fit-nurture.md`
- Updated `trinity/catalog/growth-kit/growth-audit-paid-beta-offer-sheet.md` to link to the new asset.
- Ensured all language is proof-safe and avoids fake scarcity or guru tropes.
- Verified file presence and links.

Fixes #151

---
*PR created automatically by Jules for task [2806273843576000934](https://jules.google.com/task/2806273843576000934) started by @dviveiros3*