### PR TITLE
Create Growth Audit post-launch triage guide

### DIFF
--- a/trinity/distribution/growth-audit-post-launch-triage-guide.md
+++ b/trinity/distribution/growth-audit-post-launch-triage-guide.md
@@ -78,7 +78,7 @@ Categorize every interaction before responding. Use the [Target Account Rubric](
 1.  **No Outcome Guarantees:** Never promise leads, revenue, or specific ROI.
 2.  **Use Diagnostic Language:** Use "Map," "Identify," "Audit," "Roadmap," and "Blueprint."
 3.  **Frame AI as Leverage:** AI scales the founder's *judgment*; it does not replace the founder's *voice*.
-4.  **No Scarcity Faking:** If you say "3 spots left," there must actually be exactly 3 spots left in the operational calendar.
+4.  **No Scarcity Faking:** Do not mention spots, seats, cohorts, or capacity unless that limit is operationally real and current.
 5.  **Artifact Integrity:** If sharing a screenshot, ensure it is clearly labeled as a "Sample" or "Simulated Artifact" if it’s not from a verified client.
 6.  **Polite Boundary:** If a buyer is aggressive or demanding, disqualify. Trinity is a lab for serious operators, not a commodity service provider.
 

--- a/trinity/distribution/growth-audit-post-launch-triage-guide.md
+++ b/trinity/distribution/growth-audit-post-launch-triage-guide.md
@@ -1,0 +1,92 @@
+# AI Growth Audit: Post-Launch Reply and DM Triage Guide
+
+## Mission
+To convert public attention from the Growth Audit launch into qualified conversations and market intelligence. This guide ensures Daniel maintains a high-status, founder-to-founder tone while protecting the lab's [Proof Discipline](../brand/proof-discipline.md) and capturing exact buyer signal for offer refinement.
+
+---
+
+## 1. Signal Classification Matrix
+
+Categorize every interaction before responding. Use the [Target Account Rubric](./growth-audit-target-account-rubric.md) for scoring.
+
+| Category | Profile (ICP) | Engagement Type | Intent Level | Score (1-5) |
+| --- | --- | --- | --- | --- |
+| **High Signal** | Technical Founder, SME, or Operator. | Explicit pain or specific business question. | Asks for "DIAGNOSTIC", "SYSTEM", or specs. | 4-5 |
+| **Medium Signal** | Relevant ICP or High-Leverage Peer. | General curiosity or "How-to" question. | Wants to see the sample or understand the OS. | 3 |
+| **Low Signal** | Professional in unrelated field / Non-ICP. | Generic "Great post!" or vanity engagement. | None / Low. | 1-2 |
+| **Non-Fit** | "Magic Button" seekers or Zero-Proof identity. | Asks for "automated leads" or "hands-off ROI." | High (but for the wrong thing). | 0 |
+
+---
+
+## 2. Reply & DM Templates
+
+### High Signal (The "Qualified Pilot")
+*Goal: Move to a discovery call immediately.*
+
+*   **Public Reply:** "Glad you're looking at the [Loop Name] leak, [Name]. It’s usually where the most leverage is for a technical founder. Mind if I DM you the specs for how we diagnose that?"
+*   **DM Opener:** "Hey [Name], saw your comment on the [Loop Name]. Since you're already doing [Specific Action mentioned], the diagnostic would focus on [Specific Outcome]. Would you be open to a 15-min discovery call to see if the Audit is a fit for your current volume?"
+
+### Medium Signal (The "Curious Operator")
+*Goal: Send the sample deliverable to build trust and authority.*
+
+*   **Public Reply:** "Good question, [Name]. We prioritize 'Scaling Taste' over 'Generating Slop.' I actually have a walkthrough of the diagnostic artifact that explains this. I'll send it over via DM."
+*   **DM Opener:** "Appreciate the curiosity on the Distribution OS. Most people get stuck on the content treadmill because they lack the [Proof/POV] loop. I’m sending over the **Growth Audit Deliverable Walkthrough**—it shows exactly what the roadmap looks like. Let me know if that hits the mark for you."
+
+### Low Signal (The "Reputation Builder")
+*Goal: Acknowledge and reinforce the lab's POV without deep manual time.*
+
+*   **Public Reply:** "Thanks, [Name]. Glad the 'System over Slop' thesis resonated. We're hardening the framework in the lab right now."
+*   **DM Opener:** (Usually unnecessary unless they are a high-value peer). "Appreciate the support on the launch post, [Name]. Good to see someone else values the engineering approach to growth."
+
+### Non-Fit (The "Polite Disqualification")
+*Goal: Protect lab time and maintain status without being rude.*
+
+*   **Public Reply:** "Appreciate the interest. To be clear, Trinity doesn't do lead-gen or automated outbound. We build the diagnostic and operating systems for founders to scale their own judgment. Lab Notes are probably the best place to start if you're looking for that."
+*   **DM Transition:** "Thanks for reaching out. Based on your focus on [Magic Button Request], I don't think the Growth Audit is the right fit. It's a manual-first diagnostic for founders with existing proof. I'd recommend checking out [Alternative Resource] instead."
+
+---
+
+## 3. Decision Logic: Call vs. Artifact
+
+| If they ask... | Then... |
+| --- | --- |
+| "How much does it cost?" | Send the **Paid Beta Offer Sheet** + ask a qualification question. |
+| "Can I see a sample?" | Send the **Deliverable Walkthrough**. |
+| "How does this apply to my [Specific Business]?" | Pivot to **Discovery Call**. |
+| "Is this just prompts?" | Send the **Distribution OS Framework** + explain the "Architectural" difference. |
+| "Do you guarantee leads?" | Send the **Proof-Safe Disclaimer** (Objection #6) + pivot to diagnostic value. |
+
+---
+
+## 4. Signal Capture: Post-Interaction
+*Immediately after every DM thread or call, update these fields in the [Beta Conversation Tracker](./growth-audit-beta-conversation-tracker.md):*
+
+1.  **Source:** (e.g., LinkedIn Launch Post #1)
+2.  **Buyer Profile:** (e.g., Solo Technical Founder)
+3.  **Qual Score (1-5):** (Based on the rubric)
+4.  **Exact Buyer Language:** (The phrases they used for their bottlenecks or desires)
+5.  **Objection:** (Record exact wording from the [Objection Bank](./growth-audit-objection-bank.md))
+6.  **Value Signal:** (Which part of the audit—POV, AI Skills, Roadmap—did they value most?)
+7.  **Decision:** (Yes / Maybe / No / Send Artifact)
+8.  **Next Action:** (Follow up date / Call booked / Resource sent)
+
+---
+
+## 5. Public Proof-Safety Rules
+**Strict Adherence Required for all Replies:**
+
+1.  **No Outcome Guarantees:** Never promise leads, revenue, or specific ROI.
+2.  **Use Diagnostic Language:** Use "Map," "Identify," "Audit," "Roadmap," and "Blueprint."
+3.  **Frame AI as Leverage:** AI scales the founder's *judgment*; it does not replace the founder's *voice*.
+4.  **No Scarcity Faking:** If you say "3 spots left," there must actually be exactly 3 spots left in the operational calendar.
+5.  **Artifact Integrity:** If sharing a screenshot, ensure it is clearly labeled as a "Sample" or "Simulated Artifact" if it’s not from a verified client.
+6.  **Polite Boundary:** If a buyer is aggressive or demanding, disqualify. Trinity is a lab for serious operators, not a commodity service provider.
+
+---
+
+**Related Files:**
+- [Launch Post Pack](./growth-audit-launch-post-pack.md)
+- [Target Account Rubric](./growth-audit-target-account-rubric.md)
+- [Discovery Call Script](./growth-audit-discovery-call-script.md)
+- [Objection Bank](./growth-audit-objection-bank.md)
+- [Beta Conversation Tracker](./growth-audit-beta-conversation-tracker.md)


### PR DESCRIPTION
I have created the AI Growth Audit Post-Launch Reply and DM Triage Guide. This markdown-only addition provides Daniel with a high-status operational framework for managing incoming signals from the Growth Audit launch.

Key features of the guide:
- **Triage Matrix:** Categorizes engagement into High, Medium, Low, and Non-fit signals based on ICP alignment and intent.
- **Templates:** Includes ready-to-use, proof-safe public reply and DM templates that maintain the Trinity "Founder-to-Founder" tone.
- **Decision Logic:** Clear rules for when to pivot to a 15-minute discovery call versus sending an inspectable sample artifact.
- **Operational Integration:** Links directly to the `growth-audit-beta-conversation-tracker.md` and `growth-audit-objection-bank.md` to ensure all market signal is captured for weekly offer refinement.
- **Proof Discipline:** Enforces strict public rules prohibiting lead guarantees, fake scarcity, and non-diagnostic language.

I have verified the file's content and confirmed that the repository still builds successfully. I intentionally avoided any changes to non-markdown files or application logic.

Fixes #149

---
*PR created automatically by Jules for task [1851664608565342743](https://jules.google.com/task/1851664608565342743) started by @dviveiros3*