### PR TITLE
Create Growth Audit Week 4 Publishing Packet

### DIFF
--- a/trinity/distribution/week-4-publishing-packet.md
+++ b/trinity/distribution/week-4-publishing-packet.md
@@ -2,12 +2,12 @@
 
 **Sprint:** Growth Distribution Sprint v1
 **Owner:** Daniel Viveiros
-**Goal:** Operationalize the "Offer Intelligence Loop" by demonstrating how launch signals (Yes, No, and Objections) are used to harden the Growth Audit diagnostic.
+**Goal:** Operationalize the "Offer Intelligence Loop" by demonstrating how launch signals, objections, and quiet spots are used to harden the Growth Audit diagnostic.
 
 ---
 
 ## Weekly Thesis
-Launch is not an event; it is the start of the metabolism. The value of the first week of the Growth Audit beta isn't just the revenue—it’s the raw buyer language and objections that allow us to move from a "Hypothesis" to "Observed" proof. Week 4 is about showing the market that we are listening, adjusting, and hardening the system in real-time.
+Launch is not an event; it is the start of the metabolism. The value of the first week of the Growth Audit beta is the raw buyer language, objections, and silence that tell us whether the offer is moving from "Hypothesis" toward "Observed" signal. Week 4 is about showing the market that we are listening, adjusting, and hardening the system in public without inventing traction.
 
 ---
 
@@ -15,13 +15,13 @@ Launch is not an event; it is the start of the metabolism. The value of the firs
 **Hook:** Why a "No" is more valuable than a "Like."
 
 **Body:**
-Last week I launched the **AI Growth Audit** paid beta.
+Last week I started publishing the **AI Growth Audit** paid beta.
 The goal wasn't to "go viral." The goal was to trigger the Offer Intelligence Loop.
 
 In a lab, a "No" is just as important as a "Yes."
-- If someone says "No" because of price, we've found the friction point.
-- If someone says "No" because they want "automated leads," we've found an ICP mismatch.
-- If someone says "No" because they don't see the specific workflow, we've found a proof leak.
+- If someone says "No" because of price, that may point to price friction.
+- If someone says "No" because they want "automated leads," that may point to an ICP mismatch.
+- If someone says "No" because they don't see the specific workflow, that may point to a proof leak.
 
 Most founders fear the "No" so they stay in the "Strategy Theater" of generic content.
 They optimize for vanity metrics because they are afraid to test a real offer.
@@ -47,7 +47,7 @@ To build a Distribution OS that actually works, you have to stop guessing what b
 You have to listen to what they *actually* say.
 
 Today I’m opening up the **Trinity Objection Bank**.
-This is the internal artifact where I log every piece of skepticism, friction, and "Not for me" that has come in since the launch.
+This is the internal artifact where I log skepticism, friction, and "Not for me" language as it comes in from publishing and conversations.
 
 [Drafting Note: Insert Image/Screenshot of `trinity/distribution/growth-audit-objection-bank.md` with some placeholders visible]
 
@@ -67,13 +67,13 @@ If you aren't building a library of buyer language, you aren't building an offer
 ## Post 3: Conditional (IF STRONG SIGNAL)
 **Theme:** The Pilot Velocity
 
-**Hook:** We found the leak.
+**Hook:** The first signal is pointing somewhere specific.
 
 **Body:**
-The first week of the **AI Growth Audit** beta confirmed a major hypothesis:
+The first week of the **AI Growth Audit** beta is pointing toward a stronger hypothesis:
 `[PLACEHOLDER: INSERT SUCCESSFUL HYPOTHESIS, e.g., "Founders are drowning in AI slop but starving for workflow design"].`
 
-Because of the signal we got from `[PLACEHOLDER: NUMBER]` discovery calls, we are doubling down on the `[PLACEHOLDER: SPECIFIC MODULE, e.g., Custom AI Skill Design]` part of the diagnostic.
+Because of the signal logged from `[PLACEHOLDER: SOURCE, e.g., discovery calls / DMs / comments]`, we are putting more emphasis on the `[PLACEHOLDER: SPECIFIC MODULE, e.g., Custom AI Skill Design]` part of the diagnostic.
 
 This isn't a "limited time offer" or "fake scarcity."
 It’s a lab metabolism. We follow the signal where it is strongest.
@@ -82,7 +82,7 @@ If you are a `[PLACEHOLDER: ICP SEGMENT]` dealing with `[PLACEHOLDER: SPECIFIC P
 
 **Channel:** LinkedIn
 **Intended Buyer Signal:** High-intent inquiries from the winning ICP segment.
-**CTA:** DM "PILOT" to grab one of the remaining beta diagnostic slots for this month.
+**CTA:** DM "PILOT" if you want to inspect the updated diagnostic specs before we talk.
 **Distribution OS Loop:** Offer Loop
 **Proof-Safety Note:** **ONLY PUBLISH IF** `Beta Decision Dashboard` triggers "Continue" or "Raise Price." Do not invent "remaining slots"—only state if operationally true.
 

--- a/trinity/distribution/week-4-publishing-packet.md
+++ b/trinity/distribution/week-4-publishing-packet.md
@@ -1,0 +1,166 @@
+# Trinity Distribution: Week 4 Publishing Packet
+
+**Sprint:** Growth Distribution Sprint v1
+**Owner:** Daniel Viveiros
+**Goal:** Operationalize the "Offer Intelligence Loop" by demonstrating how launch signals (Yes, No, and Objections) are used to harden the Growth Audit diagnostic.
+
+---
+
+## Weekly Thesis
+Launch is not an event; it is the start of the metabolism. The value of the first week of the Growth Audit beta isn't just the revenue—it’s the raw buyer language and objections that allow us to move from a "Hypothesis" to "Observed" proof. Week 4 is about showing the market that we are listening, adjusting, and hardening the system in real-time.
+
+---
+
+## Post 1: LinkedIn POV (The High-Status "No")
+**Hook:** Why a "No" is more valuable than a "Like."
+
+**Body:**
+Last week I launched the **AI Growth Audit** paid beta.
+The goal wasn't to "go viral." The goal was to trigger the Offer Intelligence Loop.
+
+In a lab, a "No" is just as important as a "Yes."
+- If someone says "No" because of price, we've found the friction point.
+- If someone says "No" because they want "automated leads," we've found an ICP mismatch.
+- If someone says "No" because they don't see the specific workflow, we've found a proof leak.
+
+Most founders fear the "No" so they stay in the "Strategy Theater" of generic content.
+They optimize for vanity metrics because they are afraid to test a real offer.
+
+At Trinity, we treat every objection as an engineering requirement.
+If we hear `[PLACEHOLDER: INSERT COMMON OBJECTION FROM WEEK 1]`, we don't argue. We update the diagnostic specs.
+
+The Growth Audit is becoming sharper every day because we prioritize market signal over founder ego.
+
+**Channel:** LinkedIn
+**Intended Buyer Signal:** Resonance with founders who value transparency and iterative improvement; filters for "Serious Operators."
+**CTA:** DM "SIGNAL" if you want to see the latest update to the Audit specs based on last week's buyer feedback.
+**Distribution OS Loop:** Offer Loop / Conversion Loop
+**Proof-Safety Note:** Does not claim a specific number of "No's" or "Yes's." Uses placeholders for real signal. Explicitly frames the launch as a learning exercise.
+
+---
+
+## Post 2: Proof Artifact (The Objection Bank)
+**Hook:** I don't "overcome" objections. I log them.
+
+**Body:**
+To build a Distribution OS that actually works, you have to stop guessing what buyers want.
+You have to listen to what they *actually* say.
+
+Today I’m opening up the **Trinity Objection Bank**.
+This is the internal artifact where I log every piece of skepticism, friction, and "Not for me" that has come in since the launch.
+
+[Drafting Note: Insert Image/Screenshot of `trinity/distribution/growth-audit-objection-bank.md` with some placeholders visible]
+
+We’ve seen a pattern around `[PLACEHOLDER: INSERT OBSERVED OBJECTION, e.g., "Time to Value"]`.
+Instead of ignoring it, we’re using it to pivot the `[PLACEHOLDER: INSERT SPECIFIC OFFER COMPONENT]` in the Growth Audit.
+
+If you aren't building a library of buyer language, you aren't building an offer. You're just hoping.
+
+**Channel:** LinkedIn / X
+**Intended Buyer Signal:** High-intent clicks from buyers who want to see the "Level of Rigor."
+**CTA:** You can inspect the full Objection Bank and how it influences our roadmap at `/trinity`.
+**Distribution OS Loop:** Proof Loop / Conversations Loop
+**Proof-Safety Note:** Screenshot should be of the *template* or *placeholders* unless verified signal exists. Clearly labeled as "Internal Operating Artifact."
+
+---
+
+## Post 3: Conditional (IF STRONG SIGNAL)
+**Theme:** The Pilot Velocity
+
+**Hook:** We found the leak.
+
+**Body:**
+The first week of the **AI Growth Audit** beta confirmed a major hypothesis:
+`[PLACEHOLDER: INSERT SUCCESSFUL HYPOTHESIS, e.g., "Founders are drowning in AI slop but starving for workflow design"].`
+
+Because of the signal we got from `[PLACEHOLDER: NUMBER]` discovery calls, we are doubling down on the `[PLACEHOLDER: SPECIFIC MODULE, e.g., Custom AI Skill Design]` part of the diagnostic.
+
+This isn't a "limited time offer" or "fake scarcity."
+It’s a lab metabolism. We follow the signal where it is strongest.
+
+If you are a `[PLACEHOLDER: ICP SEGMENT]` dealing with `[PLACEHOLDER: SPECIFIC PAIN]`, the Audit is now specifically hardened for your workflow.
+
+**Channel:** LinkedIn
+**Intended Buyer Signal:** High-intent inquiries from the winning ICP segment.
+**CTA:** DM "PILOT" to grab one of the remaining beta diagnostic slots for this month.
+**Distribution OS Loop:** Offer Loop
+**Proof-Safety Note:** **ONLY PUBLISH IF** `Beta Decision Dashboard` triggers "Continue" or "Raise Price." Do not invent "remaining slots"—only state if operationally true.
+
+---
+
+## Post 4: Conditional (IF LOW/NO SIGNAL)
+**Theme:** The Honest Pivot
+
+**Hook:** The market spoke. We were wrong about `[PLACEHOLDER: HYPOTHESIS]`.
+
+**Body:**
+When you run a lab, you have to be willing to kill your darlings.
+Last week we launched the **AI Growth Audit** with the hypothesis that `[PLACEHOLDER: FAILED HYPOTHESIS, e.g., "Price was the primary blocker"]`.
+
+The signal says otherwise.
+The real blocker isn't `[X]`, it's `[PLACEHOLDER: OBSERVED BLOCKER, e.g., "The intake felt too heavy for a solo founder"]`.
+
+So, we're changing the system.
+We are stripping back the `[PLACEHOLDER: COMPONENT]` and replacing it with `[PLACEHOLDER: NEW SOLUTION]`.
+
+Most people hide their "failures." I’m documenting them.
+Because a system that can't handle a "No" isn't a system you can scale.
+
+**Channel:** LinkedIn / X
+**Intended Buyer Signal:** Trust-building with skeptical peers; demonstrates high integrity.
+**CTA:** If you looked at the Audit last week and it didn't fit, check the new "Manual-First" specs at `/trinity`.
+**Distribution OS Loop:** Offer Loop / Conversion Loop
+**Proof-Safety Note:** **ONLY PUBLISH IF** `Beta Decision Dashboard` triggers "Sharpen," "Pause," or "Change ICP." This is a high-status admission of a pivot, not a defeat.
+
+---
+
+## Post 5: Short X / LinkedIn (Metabolism vs. Hype)
+**Hook:** Hype is an event. Metabolism is a system.
+
+**Body:**
+Don't optimize for a "Big Launch."
+Optimize for the loop that happens *after* the launch.
+
+The Trinity Distribution OS doesn't care about the initial splash.
+It cares about the:
+1. Objections captured.
+2. Language recorded.
+3. Offer pivots logged.
+4. Proof artifacts shipped.
+
+Build a metabolism, not just a thread.
+
+**Channel:** X / LinkedIn
+**Intended Buyer Signal:** Peer validation; high-level POV resonance.
+**CTA:** None (Reputation Builder).
+**Distribution OS Loop:** POV Loop
+**Proof-Safety Note:** Pure POV, no claims required.
+
+---
+
+## DM / Comment Follow-up Prompts
+
+### Week 4 Triage (Comment Reply)
+> "That's exactly why we added the [NEW COMPONENT] to the diagnostic this week, [Name]. We kept hearing that [OBJECTION] was the main bottleneck. Mind if I DM you the updated specs?"
+
+### The "No-Fit" Transition
+> "I appreciate the honesty on [OBJECTION], [Name]. It sounds like you're actually looking for [ALTERNATIVE SERVICE], which we don't do. I've logged your feedback into our Objection Bank—it's helping us sharpen who the Audit is actually for. I'd recommend checking out [RESOURCE] in the meantime."
+
+### The "Signal" DM (Follow-up to Post 1)
+> "Hey [Name], saw you commented 'SIGNAL'. Based on the first week of the beta, we've realized that [SPECIFIC INSIGHT] is where most founders are actually leaking value. I've updated the 90-day roadmap template to include [SPECIFIC CHANGE]. Open to seeing the new walkthrough?"
+
+---
+
+## Proof-Safety Notes (General)
+- **No Invented Signal:** Every `[PLACEHOLDER]` must be filled with real data from the `Beta Conversation Tracker` or `Objection Bank` before publishing.
+- **Decision Matrix Alignment:** Conditional posts MUST match the output of the `Beta Decision Dashboard` for the previous week.
+- **Labeling:** Any screenshots of "New Roadmaps" or "Updated Specs" must be labeled as "Simulated" or "Active Beta Sample."
+- **Integrity:** Maintain the "High-Signal Diagnostic" framing. Do not pivot to "Hurry up before they're gone" scarcity unless operationally true.
+
+---
+
+## Friday "Metabolism" Checklist
+1. [ ] **Rollup:** Ensure all Week 3 signals are moved from the `Proof Capture Log` to the `Offer-Change Log`.
+2. [ ] **Pattern Match:** Identify the single most repeated buyer phrase from the last 7 days.
+3. [ ] **Decision:** Use the `Beta Decision Dashboard` to pick between Post 3 (Strong Signal) or Post 4 (Low Signal).
+4. [ ] **Asset Sync:** Update the `/trinity` storefront copy IF a "Verified" change was triggered.


### PR DESCRIPTION
Created the Week 4 publishing packet for the Trinity Growth Audit launch follow-up. The packet focuses on the "Offer Intelligence Loop," turning launch signals into offer improvements. It includes follow-up POV posts, proof artifact posts, and conditional variants based on market signal (strong vs. low signal). All posts include strict proof-safety notes and placeholders for real buyer language, adhering to Trinity's proof discipline. I intentionally did not touch any package files or unrelated app routes.

Fixes #156

---
*PR created automatically by Jules for task [2160152350696630250](https://jules.google.com/task/2160152350696630250) started by @dviveiros3*